### PR TITLE
Security: Fix Wrangler Command Injection Vulnerability (CVE-2026-0933)

### DIFF
--- a/cloudflare-worker/package-lock.json
+++ b/cloudflare-worker/package-lock.json
@@ -13,7 +13,7 @@
         "@typescript-eslint/parser": "^6.18.0",
         "eslint": "^8.56.0",
         "typescript": "^5.9.3",
-        "wrangler": "^4.53.0"
+        "wrangler": "^4.59.1"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251209.0",
     "typescript": "^5.9.3",
-    "wrangler": "^4.53.0",
+    "wrangler": "^4.59.1",
     "eslint": "^8.56.0",
     "@typescript-eslint/parser": "^6.18.0",
     "@typescript-eslint/eslint-plugin": "^6.18.0"


### PR DESCRIPTION
## Security Fix

### Vulnerability
**Wrangler affected by OS Command Injection in `wrangler pages deploy`**

- **CVE**: CVE-2026-0933
- **GHSA**: GHSA-36p8-mvp6-cv38
- **Severity**: High (7.7/10)
- **CWE**: CWE-78 (Command Injection)

### Fix Applied
Upgraded wrangler from `^4.53.0` to `^4.59.1` in `cloudflare-worker/package.json`

Closes #3