### PR TITLE
🧹 Fix loose type usage in DOM manipulation

### DIFF
--- a/extension/entrypoints/content/button-factory.ts
+++ b/extension/entrypoints/content/button-factory.ts
@@ -3,7 +3,7 @@
  * Download button creation and event handling.
  */
 
-import type { FileMeta, ButtonState } from './types';
+import type { FileMeta, ButtonState, CqdButtonDataset } from './types';
 import { INJECTED_ATTR, PROCESSED_ATTR } from './state';
 import { toDownloadUrl } from './url-utils';
 import { extractFileMeta } from './file-meta';
@@ -32,9 +32,10 @@ export function createDownloadButton(
   button.setAttribute('title', t('titleQuick'));
 
   try {
-    if (url) (button.dataset as any).cqdUrl = url;
-    if (fileMeta?.name) (button.dataset as any).cqdName = fileMeta.name;
-    if (fileMeta?.ext) (button.dataset as any).cqdExt = fileMeta.ext;
+    const ds = button.dataset as CqdButtonDataset;
+    if (url) ds.cqdUrl = url;
+    if (fileMeta?.name) ds.cqdName = fileMeta.name;
+    if (fileMeta?.ext) ds.cqdExt = fileMeta.ext;
   } catch { /* ignore */ }
 
   // Create button internals
@@ -57,7 +58,7 @@ export function createDownloadButton(
 
   // Mouse enter: show cancel if active
   button.addEventListener('mouseenter', () => {
-    (button.dataset as any).cqdMouseOver = 'true';
+    (button.dataset as CqdButtonDataset).cqdMouseOver = 'true';
     const s = getButtonState(button);
     if (s === 'loading' || s === 'trying') {
       button.classList.add('cqd-cancel');
@@ -73,7 +74,7 @@ export function createDownloadButton(
 
   // Mouse leave: revert to active state
   button.addEventListener('mouseleave', () => {
-    (button.dataset as any).cqdMouseOver = 'false';
+    (button.dataset as CqdButtonDataset).cqdMouseOver = 'false';
     const wasCancel = button.classList.contains('cqd-cancel');
     const isUnderlyingLoading = button.classList.contains('cqd-loading');
     const isUnderlyingTrying = button.classList.contains('cqd-trying');
@@ -106,7 +107,7 @@ export function createDownloadButton(
 
     const currentState = getButtonState(button);
     if (currentState === 'cancel') {
-      delete (button.dataset as any).cqdMouseOver;
+      delete (button.dataset as CqdButtonDataset).cqdMouseOver;
       await handleCancelClick(button);
       return;
     }

--- a/extension/entrypoints/content/button-state.ts
+++ b/extension/entrypoints/content/button-state.ts
@@ -3,7 +3,7 @@
  * Button state management and rendering.
  */
 
-import type { ButtonState } from './types';
+import type { ButtonState, CqdButtonDataset } from './types';
 import {
   DOWNLOAD_ICON_SVG_URL,
   SUCCESS_ICON_SVG_URL,
@@ -83,7 +83,7 @@ export function setButtonState(
   if (!icon || !label || !errorDetail) return;
 
   const currentState = getButtonState(button);
-  const isMouseOver = (button.dataset as any).cqdMouseOver === 'true';
+  const isMouseOver = (button.dataset as CqdButtonDataset).cqdMouseOver === 'true';
 
   if (!shouldAllowTransition(currentState, state, isMouseOver)) {
     return;

--- a/extension/entrypoints/content/download-handler.ts
+++ b/extension/entrypoints/content/download-handler.ts
@@ -3,7 +3,7 @@
  * Download button click handling and background communication.
  */
 
-import type { FileMeta, PendingButton } from './types';
+import type { FileMeta, PendingButton, CqdButtonDataset } from './types';
 import {
   pendingButtons,
   getNextRequestId,
@@ -164,7 +164,7 @@ export async function waitForSuccessReset(button: HTMLButtonElement): Promise<vo
   setButtonState(button, 'idle');
   setPillProgress(button, 0);
   try {
-    delete (button.dataset as any).cqdAllDone;
+    delete (button.dataset as CqdButtonDataset).cqdAllDone;
   } catch { /* ignore */ }
 }
 
@@ -186,7 +186,7 @@ export async function handleSingleDownloadClick(
   pendingButtons.set(requestId, { button, requestId, fileMeta, startedAt });
 
   try {
-    (button.dataset as any).cqdRequestId = requestId;
+    (button.dataset as CqdButtonDataset).cqdRequestId = requestId;
   } catch { /* ignore */ }
 
   setButtonState(button, 'loading');

--- a/extension/entrypoints/content/message-handler.ts
+++ b/extension/entrypoints/content/message-handler.ts
@@ -3,7 +3,7 @@
  * Message handling for popup and download status updates.
  */
 
-import type { ButtonState } from './types';
+import type { ButtonState, CqdButtonDataset } from './types';
 import {
   pendingButtons,
   desiredEnabled,
@@ -86,7 +86,7 @@ export function setupMessageListeners(): void {
           if (status === 'success' || status === 'complete') {
             pendingButtons.delete(requestId);
             try {
-              (button.dataset as any).cqdAllDone = 'true';
+              (button.dataset as CqdButtonDataset).cqdAllDone = 'true';
             } catch { /* ignore */ }
             setPillProgress(button, 1);
             setButtonState(button, 'success');

--- a/extension/entrypoints/content/types.ts
+++ b/extension/entrypoints/content/types.ts
@@ -32,3 +32,15 @@ export type PendingButton = {
   fileMeta?: FileMeta;
   startedAt: number;
 };
+
+/**
+ * Custom dataset properties used by CQD buttons.
+ */
+export interface CqdButtonDataset extends DOMStringMap {
+  cqdUrl?: string;
+  cqdName?: string;
+  cqdExt?: string;
+  cqdMouseOver?: string;
+  cqdRequestId?: string;
+  cqdAllDone?: string;
+}

--- a/extension/entrypoints/download_all.content.ts
+++ b/extension/entrypoints/download_all.content.ts
@@ -4,6 +4,7 @@ import { t } from './content/i18n';
 import { isPageDark } from './content/theme';
 import { CANCEL_ICON_SVG_URL, DOWNLOAD_ICON_SVG_URL } from './content/icons';
 import { isClassworkPost, isTopicView } from './content/tab-detector';
+import type { CqdButtonDataset } from './content/types';
 
 
 const DOWNLOAD_BTN_SELECTOR = '.cqd-download-all-btn';
@@ -345,7 +346,7 @@ function isPostCollapsed(postRoot: HTMLElement): boolean {
 }
 
 function getCanonicalFileKey(btn: HTMLButtonElement): string {
-  const ds = btn.dataset as any;
+  const ds = btn.dataset as CqdButtonDataset;
   const url = ds.cqdUrl || '';
   if (url) {
     const idMatch =
@@ -491,7 +492,7 @@ function updateGroupState(group: GroupState): void {
     for (const b of file.buttons) {
       if (!b.isConnected) continue;
       const cls = b.classList;
-      const ds = b.dataset as any;
+      const ds = b.dataset as CqdButtonDataset;
       const isLoading = cls.contains('cqd-loading') || cls.contains('cqd-trying');
       const isSuccess = cls.contains('cqd-success') || ds.cqdAllDone === 'true';
       const isError = cls.contains('cqd-error');
@@ -1291,7 +1292,7 @@ function handleCancelAllClick(group: GroupState): void {
     const primary = getPrimaryButton(file);
     if (!primary) continue;
 
-    const fileName = (primary.dataset as any).cqdName || 'unknown';
+    const fileName = (primary.dataset as CqdButtonDataset).cqdName || 'unknown';
 
     // Mark file as cancelled
     file.inProgress = false;
@@ -1299,7 +1300,7 @@ function handleCancelAllClick(group: GroupState): void {
     cancelledCount++;
 
     // Check if requestId exists in dataset
-    const requestId = (primary.dataset as any).cqdRequestId;
+    const requestId = (primary.dataset as CqdButtonDataset).cqdRequestId;
     
     if (requestId) {
       requestIdFoundCount++;
@@ -1371,7 +1372,7 @@ function getSingleButtonState(btn: HTMLButtonElement): ButtonState {
   if (cls.contains('cqd-trying')) return 'trying';
   if (cls.contains('cqd-success')) return 'success';
   if (cls.contains('cqd-error')) return 'error';
-  if ((btn.dataset as any).cqdAllDone === 'true') return 'success';
+  if ((btn.dataset as CqdButtonDataset).cqdAllDone === 'true') return 'success';
   return 'idle';
 }
 

--- a/extension/src/download-all/group-manager.ts
+++ b/extension/src/download-all/group-manager.ts
@@ -3,7 +3,7 @@
  * Group discovery and button registration.
  */
 
-import type { GroupState, FileEntry } from './types';
+import type { GroupState, FileEntry, CqdButtonDataset } from './types';
 import {
   groupStates,
   buttonToGroup,
@@ -133,7 +133,7 @@ export function findGroupRoot(btn: HTMLElement): HTMLElement | null {
  * Get canonical file key from button data.
  */
 export function getCanonicalFileKey(btn: HTMLButtonElement): string {
-  const ds = btn.dataset as any;
+  const ds = btn.dataset as CqdButtonDataset;
   const url = ds.cqdUrl || '';
   if (url) {
     const idMatch =

--- a/extension/src/download-all/types.ts
+++ b/extension/src/download-all/types.ts
@@ -23,3 +23,15 @@ export interface GroupState {
   resetTimeoutId?: number;
   currentRunId?: number;
 }
+
+/**
+ * Custom dataset properties used by CQD buttons.
+ */
+export interface CqdButtonDataset extends DOMStringMap {
+  cqdUrl?: string;
+  cqdName?: string;
+  cqdExt?: string;
+  cqdMouseOver?: string;
+  cqdRequestId?: string;
+  cqdAllDone?: string;
+}


### PR DESCRIPTION
Refactor DOM dataset usage to be type-safe.

This change replaces loose `any` casts when accessing `dataset` properties with a strictly typed `CqdButtonDataset` interface. This improves maintainability and prevents potential runtime errors due to property name typos.

Changes:
- Defined `CqdButtonDataset` interface extending `DOMStringMap` in `extension/entrypoints/content/types.ts` and `extension/src/download-all/types.ts`.
- Updated `extension/entrypoints/content/button-factory.ts` to use `CqdButtonDataset`.
- Updated `extension/entrypoints/content/button-state.ts` to use `CqdButtonDataset`.
- Updated `extension/entrypoints/content/download-handler.ts` to use `CqdButtonDataset`.
- Updated `extension/entrypoints/content/message-handler.ts` to use `CqdButtonDataset`.
- Updated `extension/entrypoints/download_all.content.ts` to use `CqdButtonDataset`.
- Updated `extension/src/download-all/group-manager.ts` to use `CqdButtonDataset`.

Verified with `pnpm compile` (type check) and `pnpm test` (unit tests).

---
*PR created automatically by Jules for task [6434572413853283924](https://jules.google.com/task/6434572413853283924) started by @adhamhaithameid*