### PR TITLE
Sanitize ext_version in downloads_do.ts to prevent injection

### DIFF
--- a/cloudflare-worker/src/downloads_do.ts
+++ b/cloudflare-worker/src/downloads_do.ts
@@ -1454,6 +1454,7 @@ export class DownloadsDurable {
       ev.file_type = sanitizeString(ev.file_type, 24, FIELD_PATTERNS.generic);
       ev.browser = sanitizeString(ev.browser, 24, FIELD_PATTERNS.generic);
       ev.os = sanitizeString(ev.os, 24, FIELD_PATTERNS.generic);
+      ev.ext_version = sanitizeString(ev.ext_version, 24, FIELD_PATTERNS.generic);
       ev.language = sanitizeString(ev.language, 10, FIELD_PATTERNS.language);
       if (ev.error_type) {
         ev.error_type = sanitizeString(ev.error_type, 32, FIELD_PATTERNS.generic);

--- a/cloudflare-worker/tests/sanitization.test.ts
+++ b/cloudflare-worker/tests/sanitization.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { DownloadsDurable } from "../src/downloads_do";
+import type { Env } from "../src/types";
+import type { DurableObjectState } from "@cloudflare/workers-types";
+
+const STORAGE_KEY = "analytics_state";
+
+type StoredState = {
+  counters: {
+    byType: Record<string, number>;
+    byExtVersion: Record<string, number>;
+  };
+};
+
+class MockStorage {
+  private map = new Map<string, unknown>();
+  private alarm: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.map.get(key) as T;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.map.set(key, value);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.map.delete(key);
+  }
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarm;
+  }
+
+  async setAlarm(ts: number): Promise<void> {
+    this.alarm = ts;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = null;
+  }
+}
+
+class MockState {
+  storage = new MockStorage();
+  pending: Promise<unknown>[] = [];
+
+  waitUntil(promise: Promise<unknown>) {
+    this.pending.push(promise.catch(() => {}));
+  }
+}
+
+function makeDO() {
+  const state = new MockState();
+  const env: Env = {
+    ORACLE_ENDPOINT: "http://example.com",
+    DO_SHARED_SECRET: "secret",
+    MAX_BATCH_EVENTS: "10000",
+  } as Env;
+  const obj = new DownloadsDurable(state as unknown as DurableObjectState, env);
+  return { obj, state };
+}
+
+describe("Sanitization Checks", () => {
+  it("checks if ext_version is sanitized", async () => {
+    const { obj, state } = makeDO();
+    const maliciousVersion = "<script>alert('xss')</script>";
+
+    await obj.fetch(new Request("http://do/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          id: "event-1",
+          status: "success",
+          file_type: "pdf",
+          ext_version: maliciousVersion,
+          timestamp: Date.now()
+        }]
+      })
+    }));
+
+    const stored = await state.storage.get<StoredState>(STORAGE_KEY);
+    // If sanitized, the malicious key should NOT exist (it should be 'unknown')
+    expect(stored?.counters.byExtVersion[maliciousVersion]).toBeUndefined();
+    expect(stored?.counters.byExtVersion["unknown"]).toBe(1);
+  });
+
+  it("checks if file_type is sanitized", async () => {
+    const { obj, state } = makeDO();
+    const maliciousType = "<script>alert('xss')</script>";
+
+    await obj.fetch(new Request("http://do/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        events: [{
+          id: "event-2",
+          status: "success",
+          file_type: maliciousType,
+          ext_version: "1.0.0",
+          timestamp: Date.now()
+        }]
+      })
+    }));
+
+    const stored = await state.storage.get<StoredState>(STORAGE_KEY);
+    // If sanitized, the malicious key should NOT exist (it should be 'unknown')
+    // The provided code snippet in the task description suggests it MIGHT be vulnerable if not for sanitizeString
+    // But we saw sanitizeString being used.
+    expect(stored?.counters.byType[maliciousType]).toBeUndefined();
+    expect(stored?.counters.byType["unknown"]).toBe(1);
+  });
+});


### PR DESCRIPTION
Sanitize ext_version in downloads_do.ts to prevent injection

This commit addresses a security vulnerability where the `ext_version` field in analytics events was stored without sanitization. This could allow malicious actors to inject arbitrary strings or potentially execute XSS if the version string is rendered insecurely, or cause a denial of service by exhausting storage with unique keys.

The fix applies `sanitizeString` with a generic alphanumeric pattern (consistent with other fields) to `ext_version` before storage.

It also adds a regression test in `tests/sanitization.test.ts` to verify the fix.

---
*PR created automatically by Jules for task [16309825349855790227](https://jules.google.com/task/16309825349855790227) started by @adhamhaithameid*