### PR TITLE
🛡️ Sentinel: Sanitize inputs & escape HTML in dashboard utils

### DIFF
--- a/cloudflare-worker/src/dashboard/utils.ts
+++ b/cloudflare-worker/src/dashboard/utils.ts
@@ -43,11 +43,20 @@ export function topKey(data?: Record<string, number>): string {
   return entries[0][0];
 }
 
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export function renderTableRows(data: Record<string, number>): string {
   const keys = Object.keys(data).sort((a, b) => data[b] - data[a]);
   if (keys.length === 0) return "<tr><td colspan='2'>—</td></tr>";
   return keys
-    .map((k) => `<tr><td>${k}</td><td>${data[k]}</td></tr>`)
+    .map((k) => `<tr><td>${escapeHtml(k)}</td><td>${data[k]}</td></tr>`)
     .join("");
 }
 

--- a/cloudflare-worker/src/downloads_do.ts
+++ b/cloudflare-worker/src/downloads_do.ts
@@ -1523,7 +1523,7 @@ export class DownloadsDurable {
       const os = (ev.os || "unknown").toLowerCase();
       c.byOs[os] = (c.byOs[os] || 0) + eventCount;
 
-      const extVersion = ev.ext_version || "0.0.0";
+      const extVersion = sanitizeString(ev.ext_version, 12, FIELD_PATTERNS.generic, "0.0.0");
       c.byExtVersion[extVersion] =
         (c.byExtVersion[extVersion] || 0) + eventCount;
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Enhance data sanitization and output encoding

💡 Vulnerability: 
1. `ext_version` was stored without sanitization in the Durable Object, unlike other fields. Malicious versions could persist in state.
2. `renderTableRows` in `dashboard/utils.ts` did not escape HTML keys, posing a potential XSS risk if imported and used with unsanitized data (though current main dashboard usage was safe via shadowing).

🎯 Impact:
- Stored XSS if the unsanitized `ext_version` is rendered without escaping.
- XSS if `renderTableRows` from `utils.ts` is used in new dashboard features.

🔧 Fix:
- Added sanitization for `ext_version` using `sanitizeString` and `FIELD_PATTERNS.generic` in `downloads_do.ts`.
- Implemented `escapeHtml` in `dashboard/utils.ts` and applied it to table keys.

✅ Verification:
- Ran `pnpm test` in `cloudflare-worker`: 43 tests passed.
- Ran `pnpm typecheck`: Passed.
- Verified code structure confirms `sanitizeString` is available in `downloads_do.ts`.

---
*PR created automatically by Jules for task [10591546500039618250](https://jules.google.com/task/10591546500039618250) started by @adhamhaithameid*