### PR TITLE
Refactor startNextDriveAttempt to use iterative loop

### DIFF
--- a/extension/entrypoints/background/download-handler.ts
+++ b/extension/entrypoints/background/download-handler.ts
@@ -63,49 +63,59 @@ export function openDriveBypassTab(pending: PendingDownload, url: string): void 
  * Try the next auth user for a Drive download.
  * Cycles through authuser=0..9 to find one with access.
  */
-export function startNextDriveAttempt(pending: PendingDownload): void {
+export async function startNextDriveAttempt(pending: PendingDownload): Promise<void> {
   pending.htmlSeen = false;
   pending.fallbackStarted = false;
   pending.confirmed403 = false;
 
-  const nextAuth = AUTHUSER_CANDIDATES.find(
-    (n) => !pending.attemptedAuthUsers.includes(n)
-  );
-
-  if (nextAuth == null) {
-    sendStatusToTab(pending, 'error', 'Access denied for all accounts.', 'AUTH_ALL_FAILED');
-    recordDownloadEvent({
-      type: pending.fileMeta?.ext || 'unknown',
-      status: 'fail',
-      duration_ms: Date.now() - pending.startTime,
-      bypass_used: true,
-      error_type: 'AUTH_ALL_FAILED',
-    });
-    cleanup(pending);
-    return;
-  }
-
-  pending.attemptedAuthUsers.push(nextAuth);
-  pending.currentAuthUser = nextAuth;
-
-  if (IS_FIREFOX) {
-    // Firefox: Open bypass tab with next auth
-    const attemptUrl = buildUrlWithAuthUser(pending.baseUrl, nextAuth);
-    openDriveBypassTab(pending, attemptUrl);
-  } else {
-    // Chrome: Try native download
-    const attemptUrl = buildUrlWithAuthUser(pending.baseUrl, nextAuth);
-    chrome.downloads.download(
-      { url: attemptUrl, saveAs: false, conflictAction: 'uniquify' },
-      (downloadId) => {
-        if (chrome.runtime.lastError || !downloadId) {
-          startNextDriveAttempt(pending);
-          return;
-        }
-        pending.currentDownloadId = downloadId;
-        pendingByDownloadId.set(downloadId, pending);
-      }
+  while (true) {
+    const nextAuth = AUTHUSER_CANDIDATES.find(
+      (n) => !pending.attemptedAuthUsers.includes(n)
     );
+
+    if (nextAuth == null) {
+      sendStatusToTab(pending, 'error', 'Access denied for all accounts.', 'AUTH_ALL_FAILED');
+      recordDownloadEvent({
+        type: pending.fileMeta?.ext || 'unknown',
+        status: 'fail',
+        duration_ms: Date.now() - pending.startTime,
+        bypass_used: true,
+        error_type: 'AUTH_ALL_FAILED',
+      });
+      cleanup(pending);
+      return;
+    }
+
+    pending.attemptedAuthUsers.push(nextAuth);
+    pending.currentAuthUser = nextAuth;
+    const attemptUrl = buildUrlWithAuthUser(pending.baseUrl, nextAuth);
+
+    if (IS_FIREFOX) {
+      // Firefox: Open bypass tab with next auth
+      openDriveBypassTab(pending, attemptUrl);
+      return;
+    }
+
+    // Chrome: Try native download
+    const downloadId = await new Promise<number | undefined>((resolve) => {
+      chrome.downloads.download(
+        { url: attemptUrl, saveAs: false, conflictAction: 'uniquify' },
+        (id) => {
+          if (chrome.runtime.lastError || !id) {
+            resolve(undefined);
+          } else {
+            resolve(id);
+          }
+        }
+      );
+    });
+
+    if (downloadId) {
+      pending.currentDownloadId = downloadId;
+      pendingByDownloadId.set(downloadId, pending);
+      return;
+    }
+    // Loop continues if download failed to start
   }
 }
 

--- a/extension/tests/background-download-handler.test.ts
+++ b/extension/tests/background-download-handler.test.ts
@@ -175,7 +175,7 @@ describe('background download handler', () => {
       isDrive: true,
       attemptedAuthUsers: [0, 1],
     });
-    ctx.mod.startNextDriveAttempt(pending);
+    await ctx.mod.startNextDriveAttempt(pending);
     expect(ctx.sendStatusSpy).toHaveBeenCalledWith(
       pending,
       'error',
@@ -193,7 +193,7 @@ describe('background download handler', () => {
       attemptedAuthUsers: [0],
       fileMeta: undefined as any,
     });
-    ctx.mod.startNextDriveAttempt(pending);
+    await ctx.mod.startNextDriveAttempt(pending);
     expect(ctx.recordSpy).toHaveBeenCalledWith(expect.objectContaining({
       type: 'unknown',
       error_type: 'AUTH_ALL_FAILED',
@@ -204,7 +204,7 @@ describe('background download handler', () => {
     const ctx = await loadDownloadHandler({ isFirefox: true, authCandidates: [3] });
     const pending = makePending({ isDrive: true, attemptedAuthUsers: [] });
     (chrome.tabs.create as any).mockImplementation((_: unknown, cb: (tab: { id?: number }) => void) => cb({ id: 5 }));
-    ctx.mod.startNextDriveAttempt(pending);
+    await ctx.mod.startNextDriveAttempt(pending);
     expect(pending.currentAuthUser).toBe(3);
     expect(ctx.stateModule.pendingByBypassTabId.get(5)).toBe(pending);
   });
@@ -224,7 +224,7 @@ describe('background download handler', () => {
       }
     });
 
-    ctx.mod.startNextDriveAttempt(pending);
+    await ctx.mod.startNextDriveAttempt(pending);
 
     expect(calls).toBe(2);
     expect(pending.attemptedAuthUsers).toEqual([0, 1]);


### PR DESCRIPTION
Refactored `startNextDriveAttempt` in `extension/entrypoints/background/download-handler.ts` to use an iterative approach instead of recursion. This eliminates the risk of infinite recursion and improves maintainability.

The function now:
- Returns `Promise<void>`.
- Iterates through `AUTHUSER_CANDIDATES` using a `while` loop.
- Awaits the result of `chrome.downloads.download` (wrapped in a Promise).
- Handles success, failure, and Firefox bypass paths correctly.

Updated `extension/tests/background-download-handler.test.ts` to await the function calls.

---
*PR created automatically by Jules for task [15143532627314589026](https://jules.google.com/task/15143532627314589026) started by @adhamhaithameid*