### PR TITLE
🛡️ Sentinel: [HIGH] Fix Input Sanitization Bypass on ext_version

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The `cloudflare-worker` dashboard was vulnerable to Stored XSS. User-controlled inputs (changelog versions, changes, IDs) were interpolated directly into HTML strings without escaping. Additionally, configuration JSON was injected into `<script>` tags using standard `JSON.stringify`, which allows closing the script tag via `</script>`.
 **Learning:** Server-side rendering (SSR) logic must explicitly escape all untrusted data. `JSON.stringify` is insufficient for embedding data in HTML `<script>` contexts because it does not escape HTML characters like `<` and `>`.
 **Prevention:** Always use an HTML escaping utility (like `escapeHtml`) for string interpolation in HTML. For JSON in `<script>` tags, use a safe serializer that unicode-escapes `<` and `>` (e.g., `\u003c`, `\u003e`).
+
+## 2026-02-12 - Input Sanitization Bypass in Analytics Event
+**Vulnerability:** The `ext_version` field in analytics events was not sanitized, unlike other fields. While total event size was limited (10KB), a malicious actor could send many events with unique, large `ext_version` strings (e.g. 9KB each), causing the Durable Object state (which aggregates by this key) to grow unbounded in memory, potentially leading to DoS.
+**Learning:** When implementing field-based aggregation, ALL keys must be sanitized and bounded, not just "high-cardinality" ones. Even "low-cardinality" fields like version numbers can be abused if the input is not validated.
+**Prevention:** Apply `sanitizeString` with strict length limits and regex patterns to ALL input fields used as map keys in aggregation logic.

--- a/cloudflare-worker/src/downloads_do.ts
+++ b/cloudflare-worker/src/downloads_do.ts
@@ -1650,6 +1650,7 @@ export class DownloadsDurable {
       ev.browser = sanitizeString(ev.browser, 24, FIELD_PATTERNS.generic);
       ev.os = sanitizeString(ev.os, 24, FIELD_PATTERNS.generic);
       ev.language = sanitizeString(ev.language, 10, FIELD_PATTERNS.language);
+      ev.ext_version = sanitizeString(ev.ext_version, 32, FIELD_PATTERNS.generic, "0.0.0");
       if (ev.error_type) {
         ev.error_type = sanitizeString(ev.error_type, 32, FIELD_PATTERNS.generic);
       }
@@ -1696,7 +1697,7 @@ export class DownloadsDurable {
       const os = (ev.os || "unknown").toLowerCase();
       c.byOs[os] = (c.byOs[os] || 0) + eventCount;
 
-      const extVersion = ev.ext_version || "0.0.0";
+      const extVersion = ev.ext_version;
       c.byExtVersion[extVersion] =
         (c.byExtVersion[extVersion] || 0) + eventCount;
 
@@ -3089,7 +3090,7 @@ export class DownloadsDurable {
       const lang = (ev.language || "unknown").toLowerCase();
       summary.languages[lang] = (summary.languages[lang] || 0) + weight;
 
-      const ver = ev.ext_version || "0.0.0";
+      const ver = sanitizeString(ev.ext_version, 32, FIELD_PATTERNS.generic, "0.0.0");
       summary.versions[ver] = (summary.versions[ver] || 0) + weight;
 
       const type = (ev.file_type || "unknown").toLowerCase();
@@ -3210,7 +3211,7 @@ export class DownloadsDurable {
       const os = (ev.os || "unknown").toLowerCase();
       counters.byOs[os] = (counters.byOs[os] || 0) + weight;
 
-      const extVer = ev.ext_version || "0.0.0";
+      const extVer = sanitizeString(ev.ext_version, 32, FIELD_PATTERNS.generic, "0.0.0");
       counters.byExtVersion[extVer] = (counters.byExtVersion[extVer] || 0) + weight;
 
       const lang = (ev.language || "unknown").toLowerCase();

--- a/cloudflare-worker/tests/sanitization.test.ts
+++ b/cloudflare-worker/tests/sanitization.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { DownloadsDurable } from "../src/downloads_do";
+import type { Env } from "../src/types";
+import type { DurableObjectState } from "@cloudflare/workers-types";
+
+const STORAGE_KEY = "analytics_state";
+
+type StoredAnalyticsState = {
+  counters: {
+    byExtVersion: Record<string, number>;
+  };
+};
+
+// Mock Storage and State (Simplified from security.test.ts)
+class MockStorage {
+  private map = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.map.get(key) as T;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.map.set(key, value);
+  }
+
+  async getAlarm() { return null; }
+  async setAlarm() {}
+}
+
+class MockState {
+  storage = new MockStorage();
+  pending: Promise<unknown>[] = [];
+  waitUntil(promise: Promise<unknown>) { this.pending.push(promise.catch(() => {})); }
+}
+
+function makeDO() {
+  const state = new MockState();
+  const env: Env = {
+    ORACLE_ENDPOINT: "http://example.com",
+    DO_SHARED_SECRET: "secret",
+    MAX_BATCH_EVENTS: "10000",
+  } as Env;
+  const obj = new DownloadsDurable(state as unknown as DurableObjectState, env);
+  return { obj, state };
+}
+
+function makeTrackRequest(id: string, extVersion: string): Request {
+  return new Request("http://do/track", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      events: [{
+        id,
+        status: "success",
+        file_type: "pdf",
+        browser: "chrome",
+        os: "mac",
+        ext_version: extVersion,
+        timestamp: Date.now(),
+      }],
+    }),
+  });
+}
+
+describe("ext_version sanitization", () => {
+  it("routes invalid ext_version values into the bounded fallback bucket", async () => {
+    const { obj, state } = makeDO();
+    const invalidVersions = [
+      "<script>alert(1)</script>",
+      "v1.2.3 release",
+      "a".repeat(200),
+    ];
+
+    for (const [idx, extVersion] of invalidVersions.entries()) {
+      const res = await obj.fetch(makeTrackRequest(`bad-${idx}`, extVersion));
+      expect(res.status).toBe(202);
+    }
+
+    const stored = await state.storage.get<StoredAnalyticsState>(STORAGE_KEY);
+    const buckets = stored?.counters.byExtVersion ?? {};
+
+    expect(buckets["0.0.0"]).toBe(invalidVersions.length);
+    expect(buckets["<script>alert(1)</script>"]).toBeUndefined();
+    expect(buckets["v1.2.3 release"]).toBeUndefined();
+  });
+
+  it("accepts valid ext_version values and normalizes casing", async () => {
+    const { obj, state } = makeDO();
+
+    const res = await obj.fetch(makeTrackRequest("ok-1", " V1.2.3-BETA "));
+    expect(res.status).toBe(202);
+
+    const stored = await state.storage.get<StoredAnalyticsState>(STORAGE_KEY);
+    const buckets = stored?.counters.byExtVersion ?? {};
+
+    expect(buckets["v1.2.3-beta"]).toBe(1);
+    expect(buckets["0.0.0"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Vulnerability Fix: Input Sanitization Bypass**

The `ext_version` field in analytics events was not sanitized, unlike other fields. While the total event size was limited (10KB), a malicious actor could send many events with unique, large `ext_version` strings (e.g., 9KB each). Since the Durable Object aggregates counts by this key, this could lead to unbounded memory growth (DoS) or database bloat.

**Changes:**
- Applied `sanitizeString` to `ev.ext_version` in `cloudflare-worker/src/downloads_do.ts` with a 32-character limit and strict regex whitelist (`FIELD_PATTERNS.generic`), defaulting to `"0.0.0"`.
- Added a new test suite `cloudflare-worker/tests/sanitization.test.ts` that verifies the sanitization logic.

**Verification:**
- Ran `pnpm test` in `cloudflare-worker/`, which now includes the new sanitization test and all existing regression tests. All passed.

---
*PR created automatically by Jules for task [9024354957121337623](https://jules.google.com/task/9024354957121337623) started by @adhamhaithameid*