### PR TITLE
🎨 Palette: Add missing tooltips and labels for better accessibility

### DIFF
--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -712,7 +712,14 @@ function App() {
                 <h3 className="cqd-cl-title">
                   <span className="btn-bullet">📜</span> What's New
                 </h3>
-                <button className="cqd-cl-close" onClick={() => setShowChangelog(false)}>×</button>
+                <button
+                  className="cqd-cl-close"
+                  onClick={() => setShowChangelog(false)}
+                  aria-label="Close changelog"
+                  title="Close"
+                >
+                  ×
+                </button>
               </div>
               <div className="cqd-cl-body">
                 {changelogData?.entries?.length ? (
@@ -762,6 +769,7 @@ function App() {
                 className="cqd-banner-close"
                 onClick={() => setError(null)}
                 aria-label="Dismiss error message"
+                title="Dismiss error message"
               >
                 ×
               </button>
@@ -955,6 +963,7 @@ function App() {
                   rel="noreferrer"
                   className="cqd-button cqd-button-primary"
                   aria-label="Open the GitHub repository"
+                  title="Open the GitHub repository"
                 >
                   <span className="cqd-button-icon">
                     <svg
@@ -982,6 +991,7 @@ function App() {
                     )
                   }
                   aria-label="Support the developer on Buy Me a Coffee"
+                  title="Support the developer on Buy Me a Coffee"
                 >
                   <img
                     src={bmcLogoSrc}


### PR DESCRIPTION
*   💡 **What:** Added `title` attributes to GitHub, Buy Me a Coffee, and Error Banner buttons. Added `aria-label` and `title` to the Changelog Close button.
*   🎯 **Why:** To improve accessibility for screen reader users (missing label on close button) and usability for mouse users (missing tooltips on icon-only buttons).
*   ♿ **Accessibility:** The changelog close button is now properly labeled for screen readers. All icon-only buttons now have tooltips.
*   📸 **Verification:** Verified with Playwright script and screenshot. Ran `tsc` and existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [4454225823291487301](https://jules.google.com/task/4454225823291487301) started by @adhamhaithameid*