### PR TITLE
🎨 Palette: Improve Changelog Modal Accessibility

### DIFF
--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -334,6 +334,30 @@ function App() {
   // CHANGELOG STATE
   const [changelogData, setChangelogData] = useState<ChangelogData | null>(null);
   const [showChangelog, setShowChangelog] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (showChangelog) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      closeButtonRef.current?.focus();
+    } else {
+      if (previousFocusRef.current) {
+        previousFocusRef.current.focus();
+        previousFocusRef.current = null;
+      }
+    }
+  }, [showChangelog]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape' && showChangelog) {
+        setShowChangelog(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showChangelog]);
 
   // Track scroll to add blur/shadow under header when not at top
   useEffect(() => {
@@ -704,15 +728,28 @@ function App() {
 
         <div className="cqd-content-area">
           {/* ChangeLog Overlay */}
-          <div className={`cqd-changelog-overlay ${showChangelog ? 'open' : ''}`} onClick={(e) => {
-             if (e.target === e.currentTarget) setShowChangelog(false);
-          }}>
+          <div
+            className={`cqd-changelog-overlay ${showChangelog ? 'open' : ''}`}
+            onClick={(e) => {
+              if (e.target === e.currentTarget) setShowChangelog(false);
+            }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="changelog-title"
+          >
             <div className="cqd-changelog-card">
               <div className="cqd-cl-header">
-                <h3 className="cqd-cl-title">
+                <h3 className="cqd-cl-title" id="changelog-title">
                   <span className="btn-bullet">📜</span> What's New
                 </h3>
-                <button className="cqd-cl-close" onClick={() => setShowChangelog(false)}>×</button>
+                <button
+                  className="cqd-cl-close"
+                  onClick={() => setShowChangelog(false)}
+                  ref={closeButtonRef}
+                  aria-label="Close changelog"
+                >
+                  ×
+                </button>
               </div>
               <div className="cqd-cl-body">
                 {changelogData?.entries?.length ? (

--- a/extension/tests/popup-changelog-a11y.test.ts
+++ b/extension/tests/popup-changelog-a11y.test.ts
@@ -1,0 +1,171 @@
+import { act, createElement } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../entrypoints/popup/App';
+
+type LocalStorageData = Record<string, unknown>;
+
+function readLocalValue(state: LocalStorageData, key: unknown): Record<string, unknown> {
+  if (typeof key === 'string') {
+    return { [key]: state[key] };
+  }
+  if (Array.isArray(key)) {
+    return key.reduce<Record<string, unknown>>((acc, current) => {
+      acc[current] = state[current];
+      return acc;
+    }, {});
+  }
+  return {};
+}
+
+function createChromeMock(initialState: LocalStorageData) {
+  const state: LocalStorageData = { ...initialState };
+  const listeners = new Set<(changes: unknown, area: string) => void>();
+
+  const local = {
+    get: vi.fn((key: unknown, callback?: (result: Record<string, unknown>) => void) => {
+      const result = readLocalValue(state, key);
+      if (typeof callback === 'function') {
+        callback(result);
+        return;
+      }
+      return Promise.resolve(result);
+    }),
+    set: vi.fn((next: Record<string, unknown>, callback?: () => void) => {
+      Object.assign(state, next);
+      if (typeof callback === 'function') callback();
+      return Promise.resolve();
+    }),
+  };
+
+  return {
+    runtime: {
+      getManifest: () => ({ version: '1.3.0' }),
+      lastError: null,
+    },
+    tabs: {
+      query: vi.fn((_query: unknown, callback: (tabs: Array<{ id: number; url: string }>) => void) => {
+        callback([{ id: 1, url: 'https://classroom.google.com/' }]);
+      }),
+      create: vi.fn(),
+    },
+    storage: {
+      local,
+      onChanged: {
+        addListener: vi.fn((listener: (changes: unknown, area: string) => void) => {
+          listeners.add(listener);
+        }),
+        removeListener: vi.fn((listener: (changes: unknown, area: string) => void) => {
+          listeners.delete(listener);
+        }),
+      },
+    },
+  };
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function waitForElement(container: HTMLElement, selector: string): Promise<HTMLElement | null> {
+  for (let i = 0; i < 20; i += 1) {
+    const item = container.querySelector(selector) as HTMLElement | null;
+    if (item) return item;
+    await act(async () => {
+      await tick();
+    });
+  }
+  return null;
+}
+
+describe('popup changelog accessibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    localStorage.clear();
+    const chromeMock = createChromeMock({
+      extensionEnabled: true,
+      cqd_changelog_seen_v1: [],
+    });
+
+    (globalThis as any).chrome = chromeMock;
+    (globalThis as any).open = vi.fn();
+
+    // Mock fetch for changelog to avoid network errors
+    global.fetch = vi.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({
+        entries: [],
+        config: {},
+        ok: true
+      })
+    })) as any;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    localStorage.clear();
+    delete (globalThis as any).chrome;
+    delete (globalThis as any).IS_REACT_ACT_ENVIRONMENT;
+    vi.restoreAllMocks();
+  });
+
+  it('manages focus and ARIA attributes correctly for changelog modal', async () => {
+    await act(async () => {
+      flushSync(() => {
+        root.render(createElement(App));
+      });
+      await tick();
+      await tick();
+    });
+
+    // 1. Find and Click Version Button
+    const versionBtn = await waitForElement(container, '.cqd-brand-version');
+    expect(versionBtn).not.toBeNull();
+
+    // Check initial focus
+    await act(async () => {
+      versionBtn?.focus();
+      versionBtn?.click();
+      await tick();
+    });
+
+    // 2. Verify Modal is Open and has ARIA attributes
+    const modal = await waitForElement(container, '.cqd-changelog-overlay.open');
+    expect(modal).not.toBeNull();
+    expect(modal?.getAttribute('role')).toBe('dialog');
+    expect(modal?.getAttribute('aria-modal')).toBe('true');
+    expect(modal?.getAttribute('aria-labelledby')).toBe('changelog-title');
+
+    // 3. Verify Focus moved to Close Button
+    const closeBtn = container.querySelector('.cqd-cl-close') as HTMLButtonElement;
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn.getAttribute('aria-label')).toBe('Close changelog');
+    expect(document.activeElement).toBe(closeBtn);
+
+    // 4. Verify Title ID
+    const title = container.querySelector('.cqd-cl-title');
+    expect(title?.getAttribute('id')).toBe('changelog-title');
+
+    // 5. Close Modal via Escape Key
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await tick();
+    });
+
+    // 6. Verify Modal Closed
+    expect(container.querySelector('.cqd-changelog-overlay.open')).toBeNull();
+
+    // 7. Verify Focus Restored to Version Button
+    expect(document.activeElement).toBe(versionBtn);
+  });
+});


### PR DESCRIPTION
*   💡 What: Added ARIA attributes, focus management, and keyboard navigation to the Changelog modal in the extension popup.
*   🎯 Why: To make the modal accessible for keyboard and screen reader users, following WCAG guidelines.
*   ♿ Accessibility:
    *   Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to modal container.
    *   Added `aria-label` to Close button.
    *   Implemented focus management (focus moves to Close button on open, restores to trigger on close).
    *   Added `Escape` key support to close modal.
*   ✅ Verified: Unit test `extension/tests/popup-changelog-a11y.test.ts` passed. `pnpm compile` passed.

---
*PR created automatically by Jules for task [9097900069068604418](https://jules.google.com/task/9097900069068604418) started by @adhamhaithameid*