### PR TITLE
ci(oracle): fix deploy smoke origin selection

### DIFF
--- a/.github/workflows/oracle-dashboard-deploy.yml
+++ b/.github/workflows/oracle-dashboard-deploy.yml
@@ -152,9 +152,13 @@ jobs:
             echo "$snapshot_payload" | grep -Eq '"schemaVersion"[[:space:]]*:[[:space:]]*"1"'
 
             smoke_origin="$(grep -E '^PUBLIC_WEBSITE_ALLOWED_ORIGINS=' .env.production | head -n1 | cut -d= -f2- | tr ',' '\n' | head -n1 | xargs)"
-            if [ -z "$smoke_origin" ]; then
+            if [ -z "$smoke_origin" ] || printf '%s' "$smoke_origin" | grep -Eqi 'replace_me|example\.com'; then
               smoke_origin="https://classroom-quick-downloader-website.pages.dev"
             fi
+            case "$smoke_origin" in
+              http://*|https://*) ;;
+              *) smoke_origin="https://classroom-quick-downloader-website.pages.dev" ;;
+            esac
             event_id="gha-oracle-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
             ingest_payload="$(cat <<JSON
             {"schemaVersion":"1","sessionId":"gha-oracle-smoke","pagePath":"/ci/smoke","events":[{"eventId":"${event_id}","eventType":"cta","action":"install_click","placement":"hero_install"}]}


### PR DESCRIPTION
## Fix
- Harden Oracle deploy smoke-origin selection in `.github/workflows/oracle-dashboard-deploy.yml`.
- Ignore placeholder/invalid origins (like `REPLACE_ME`/`example.com`) and fall back to the production website origin.
- Enforce URL scheme check before using the value in the ingest smoke call.

## Why
The previous run failed with HTTP 400 on `/api/public/website/events` after a successful deploy because the first configured allowed origin on VM was a placeholder value.

## Validation
- `bash tools/check_schema_compat.sh`
