### PR TITLE
ci(oracle): fix SSH shell parse error in smoke origin guard

### DIFF
--- a/.github/workflows/oracle-dashboard-deploy.yml
+++ b/.github/workflows/oracle-dashboard-deploy.yml
@@ -155,10 +155,9 @@ jobs:
             if [ -z "$smoke_origin" ] || printf '%s' "$smoke_origin" | grep -Eqi 'replace_me|example\.com'; then
               smoke_origin="https://classroom-quick-downloader-website.pages.dev"
             fi
-            case "$smoke_origin" in
-              http://*|https://*) ;;
-              *) smoke_origin="https://classroom-quick-downloader-website.pages.dev" ;;
-            esac
+            if ! printf '%s' "$smoke_origin" | grep -Eq '^https?://'; then
+              smoke_origin="https://classroom-quick-downloader-website.pages.dev"
+            fi
             event_id="gha-oracle-${GITHUB_RUN_ID:-manual}-${GITHUB_RUN_ATTEMPT:-1}"
             ingest_payload="$(cat <<JSON
             {"schemaVersion":"1","sessionId":"gha-oracle-smoke","pagePath":"/ci/smoke","events":[{"eventId":"${event_id}","eventType":"cta","action":"install_click","placement":"hero_install"}]}


### PR DESCRIPTION
Follow-up to #351: replace the case statement with a POSIX-safe regex check for smoke origin validation in Oracle deploy workflow.\n\nValidation:\n- bash tools/check_schema_compat.sh