### PR TITLE
⚡ Bolt: Memoize combined language keywords

### DIFF
--- a/extension/entrypoints/content/detection-keywords.ts
+++ b/extension/entrypoints/content/detection-keywords.ts
@@ -699,3 +699,41 @@ export function isExcludedEditedPattern(text: string): boolean {
   const normalized = normalizeForComparison(text);
   return EDITED_EXCLUSION_PATTERNS.some(p => normalized.includes(normalizeForComparison(p)));
 }
+
+// ============================================================================
+// MEMOIZED COMBINED KEYWORDS
+// ============================================================================
+
+const combinedCommentKeywordsCache = new Map<string, CommentKeywords>();
+const combinedEditedKeywordsCache = new Map<string, string[]>();
+
+export function getCombinedCommentKeywords(lang: string): CommentKeywords {
+  if (combinedCommentKeywordsCache.has(lang)) {
+    return combinedCommentKeywordsCache.get(lang)!;
+  }
+  const keywords = getCommentKeywords(lang);
+  const englishKeywords = getCommentKeywords('en');
+  const arabicKeywords = getCommentKeywords('ar');
+
+  const combined: CommentKeywords = {
+    singular: [...new Set([...keywords.singular, ...englishKeywords.singular, ...arabicKeywords.singular])],
+    plural: [...new Set([...keywords.plural, ...englishKeywords.plural, ...arabicKeywords.plural])],
+    classComment: [...new Set([...keywords.classComment, ...englishKeywords.classComment, ...arabicKeywords.classComment])],
+  };
+
+  combinedCommentKeywordsCache.set(lang, combined);
+  return combined;
+}
+
+export function getCombinedEditedKeywords(lang: string): string[] {
+  if (combinedEditedKeywordsCache.has(lang)) {
+    return combinedEditedKeywordsCache.get(lang)!;
+  }
+  const keywords = getEditedKeywords(lang);
+  const englishKeywords = getEditedKeywords('en');
+  const arabicKeywords = getEditedKeywords('ar');
+
+  const combined = [...new Set([...keywords, ...englishKeywords, ...arabicKeywords])];
+  combinedEditedKeywordsCache.set(lang, combined);
+  return combined;
+}

--- a/extension/entrypoints/content/smart-detector-comments.ts
+++ b/extension/entrypoints/content/smart-detector-comments.ts
@@ -22,6 +22,7 @@ import {
   normalizeForComparison,
   parseUnicodeInteger,
   getCommentKeywords,
+  getCombinedCommentKeywords,
   isExcludedCommentPattern,
   type CommentKeywords,
 } from './detection-keywords';
@@ -515,17 +516,8 @@ function executeLayer4_NuclearScan(post: HTMLElement, keywords: CommentKeywords)
 // ============================================================================
 
 export function detectComments(post: HTMLElement, pageLang: string): CommentDetectionResult {
-  // Get keywords for current language + English fallback + Arabic (common)
-  const keywords = getCommentKeywords(pageLang);
-  const englishKeywords = getCommentKeywords('en');
-  const arabicKeywords = getCommentKeywords('ar');
-  
-  // Combine keywords (deduplicated)
-  const combinedKeywords: CommentKeywords = {
-    singular: [...new Set([...keywords.singular, ...englishKeywords.singular, ...arabicKeywords.singular])],
-    plural: [...new Set([...keywords.plural, ...englishKeywords.plural, ...arabicKeywords.plural])],
-    classComment: [...new Set([...keywords.classComment, ...englishKeywords.classComment, ...arabicKeywords.classComment])],
-  };
+  // Combine keywords (deduplicated) using memoized helper
+  const combinedKeywords = getCombinedCommentKeywords(pageLang);
   
   // LAYER 0: DOM TRUTH (ABSOLUTE AUTHORITY)
   // If the specific Classwork comment container exists, its value is the AUTHORITY

--- a/extension/entrypoints/content/smart-detector.ts
+++ b/extension/entrypoints/content/smart-detector.ts
@@ -12,6 +12,7 @@ import {
   normalizeText,
   normalizeForComparison,
   getEditedKeywords,
+  getCombinedEditedKeywords,
   hasDatePattern,
   isExcludedEditedPattern,
 } from './detection-keywords';
@@ -386,12 +387,8 @@ function executeEditedLayer4(post: HTMLElement, matchedText: string | null): Lay
 // ============================================================================
 
 export function detectEdited(post: HTMLElement, pageLang: string): EditedDetectionResult {
-  const keywords = getEditedKeywords(pageLang);
-  const englishKeywords = getEditedKeywords('en');
-  const arabicKeywords = getEditedKeywords('ar');
-  
   // Always include English and Arabic as fallbacks for maximum detection
-  const combinedKeywords = [...new Set([...keywords, ...englishKeywords, ...arabicKeywords])];
+  const combinedKeywords = getCombinedEditedKeywords(pageLang);
   
   const layer1 = executeEditedLayer1(post, combinedKeywords);
   const layer2 = executeEditedLayer2(post, combinedKeywords);


### PR DESCRIPTION
⚡ Bolt: [memoize combined language keywords for smart detectors]

💡 What: Extracted the creation and Set deduplication of the combined language keywords arrays from `detectComments` and `detectEdited` into dedicated cache-backed helper functions (`getCombinedCommentKeywords` and `getCombinedEditedKeywords`) in `detection-keywords.ts`.
🎯 Why: The previous implementation was redundantly recreating and deduplicating these arrays on *every* invocation of the detection functions, which are called repeatedly for every post inside the hot `MutationObserver` scan loop. This optimization prevents unnecessary garbage collection pressure and CPU overhead from constant array allocations and `Set` initializations.
📊 Impact: Reduces array allocations and Set deduplication overhead during `MutationObserver` scan cycles to O(1) per active language instead of O(N) where N is the number of processed posts.
🔬 Measurement: Verify memory and CPU profiles in the browser DevTools while scrolling through a Google Classroom Stream with multiple posts and the extension active. The overhead of the detection cycle should be noticeably lower.

---
*PR created automatically by Jules for task [839342256061942858](https://jules.google.com/task/839342256061942858) started by @adhamhaithameid*