### PR TITLE
fix(extension): apply changelog dialog aria only when open

### DIFF
--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -846,14 +846,18 @@ function App() {
 
         <div className="cqd-content-area">
           {/* ChangeLog Overlay */}
-          <div className={`cqd-changelog-overlay ${showChangelog ? 'open' : ''}`} onClick={(e) => {
+          <div
+            className={`cqd-changelog-overlay ${showChangelog ? 'open' : ''}`}
+            aria-hidden={!showChangelog}
+            onClick={(e) => {
              if (e.target === e.currentTarget) setShowChangelog(false);
-          }}>
+            }}
+          >
             <div
               className="cqd-changelog-card"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="changelog-title"
+              role={showChangelog ? 'dialog' : undefined}
+              aria-modal={showChangelog ? true : undefined}
+              aria-labelledby={showChangelog ? 'changelog-title' : undefined}
             >
               <div className="cqd-cl-header">
                 <h3 id="changelog-title" className="cqd-cl-title">


### PR DESCRIPTION
Follow-up accessibility hotfix after #373 merge:\n- Gate  and  by changelog open state\n- Mark closed overlay as \n\nValidation:\n- 
> Classroom Quick Downloader@1.3.9 compile /Users/adhamhaithameid/Desktop/code/Classroom-Quick-Downloader/extension
> tsc --noEmit\n- 
> Classroom Quick Downloader@1.3.9 test /Users/adhamhaithameid/Desktop/code/Classroom-Quick-Downloader/extension
> vitest run


 RUN  v4.0.18 /Users/adhamhaithameid/Desktop/code/Classroom-Quick-Downloader/extension

 ✓ tests/entrypoints-smoke.test.ts (1 test) 281ms
 ✓ tests/analytics-flush-runtime.test.ts (25 tests) 399ms
 ✓ tests/content-button-factory.test.ts (3 tests) 486ms
 ✓ tests/content-flags.test.ts (3 tests) 521ms
     ✓ creates comment and edited badges with click behavior  351ms
 ✓ tests/content-both-badge.test.ts (3 tests) 643ms
     ✓ creates and updates combined badge when both attributes are present  364ms
 ✓ tests/popup-legend-a11y.test.ts (1 test) 531ms
     ✓ allows legend items to be focused and controlled via keyboard  529ms
 ✓ tests/background-index.test.ts (1 test) 105ms
 ✓ tests/content-styles.test.ts (1 test) 167ms
 ✓ tests/content-theme.test.ts (4 tests) 303ms
 ✓ tests/analytics-index-runtime.test.ts (5 tests) 260ms
 ✓ tests/dom.test.ts (45 tests) 1983ms
       ✓ [ar-1] Arabic: Single class comment with word-number "واحد"  499ms
 ✓ tests/ui.test.ts (29 tests) 234ms
 ✓ tests/utils-changelog.massive.test.ts (1560 tests) 78ms
 ✓ tests/popup-toggle-switch.test.ts (3 tests) 71ms
 ✓ tests/content-button-state.test.ts (4 tests) 69ms
 ✓ tests/utils-language-controller.test.ts (7 tests) 32ms
 ✓ tests/integration-extension-cloudflare.test.ts (3 tests) 94ms
 ✓ tests/analytics-storage.test.ts (32 tests) 104ms
 ✓ tests/content-pulse-effect.test.ts (3 tests) 96ms
 ✓ tests/content-observers.test.ts (5 tests) 168ms
 ✓ tests/content-message-handler.test.ts (5 tests) 51ms
 ✓ tests/background-download-handler.test.ts (21 tests) 120ms
 ✓ tests/core.test.ts (60 tests) 9ms
 ✓ tests/content-download-handler.test.ts (5 tests) 32ms
 ✓ tests/background-analytics-alarm.test.ts (4 tests) 25ms
 ✓ tests/content-state.test.ts (4 tests) 19ms
 ✓ tests/content-tab-detector.test.ts (3 tests) 22ms
 ✓ tests/cancel.test.ts (47 tests) 25ms
 ✓ tests/analytics-detection.test.ts (25 tests) 17ms
 ✓ tests/analytics-cancelled-accounting.integration.test.ts (2 tests) 20ms
 ✓ tests/utils-global-state.test.ts (4 tests) 9ms
 ✓ tests/utils-changelog.test.ts (8 tests) 25ms
 ✓ tests/content-i18n.test.ts (3 tests) 18ms
 ✓ tests/analytics-flush.test.ts (28 tests) 15ms
 ✓ tests/utils-analytics-reexports.test.ts (4 tests) 24ms
 ✓ tests/analytics-rate-limiter.test.ts (4 tests) 8ms
 ✓ tests/content-url-utils.test.ts (5 tests) 22ms
 ✓ tests/xss-prevention.test.ts (19 tests) 4ms
 ✓ tests/background-icon-manager.test.ts (5 tests) 4ms
 ✓ tests/analytics-storage-internals.test.ts (10 tests) 12ms
 ✓ tests/background-cleanup.test.ts (4 tests) 10ms
 ✓ tests/content-file-meta.test.ts (5 tests) 6ms
 ✓ tests/background-auth-utils.test.ts (4 tests) 9ms
 ✓ tests/scan_optimization.test.ts (5 tests) 4ms
 ✓ tests/utils-firefox-debug.test.ts (3 tests) 3ms
 ✓ tests/background-state.test.ts (4 tests) 4ms
 ✓ tests/background-message-sender.test.ts (4 tests) 4ms
 ✓ tests/background-url-helpers.test.ts (7 tests) 3ms

 Test Files  48 passed (48)
      Tests  2040 passed (2040)
   Start at  15:08:38
   Duration  9.70s (transform 2.39s, setup 2.70s, import 2.40s, tests 7.15s, environment 41.98s)