### PR TITLE
fix(security): patch reachable Go stdlib vulns via 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
@@ -247,7 +247,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Oracle Backend Heavy Test Matrix
         run: pnpm -C oracle-backend test:strict
@@ -296,7 +296,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Migration Bootstrap + Tests
         working-directory: oracle-backend

--- a/.github/workflows/oracle-backend-ci.yml
+++ b/.github/workflows/oracle-backend-ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Oracle heavy test matrix
         run: pnpm -C oracle-backend test:strict
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run migration bootstrap tests
         working-directory: oracle-backend
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Generate runtime smoke secrets
         run: |
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Ensure no committed Google credential files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ oracle-backend/google-credentials*.json
 
 ownership-map-out/
 ownership-map-out-sensitive/
+report.md

--- a/oracle-backend/go.mod
+++ b/oracle-backend/go.mod
@@ -1,7 +1,7 @@
 // filepath: oracle-backend/go.mod
 module oracle-backend
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/jackc/pgx/v5 v5.9.1


### PR DESCRIPTION
## Summary
This PR fixes a critical security finding discovered during the 2026-04-10 full-repo Friday scanner run.

`govulncheck` reported **5 reachable Go standard-library vulnerabilities** while the backend was pinned to `go1.26.1`.
All 5 are fixed in `go1.26.2`.

### Vulnerabilities detected in the pre-fix scan
- `GO-2026-4947` (`crypto/x509`)
- `GO-2026-4946` (`crypto/x509`)
- `GO-2026-4870` (`crypto/tls`, DoS class)
- `GO-2026-4866` (`crypto/x509`, auth-bypass class)
- `GO-2026-4865` (`html/template`, XSS class)

## Plan
1. Upgrade backend Go toolchain declaration to `1.26.2`.
2. Upgrade backend CI jobs to use `go-version: 1.26.2` (so CI and runtime validation match).
3. Re-run security and validation suites to confirm the vulnerabilities are cleared.
4. Keep commits small, isolated, and easy to revert.

## Changes
- `oracle-backend/go.mod`
  - `go 1.26.1` -> `go 1.26.2`
- `.github/workflows/ci.yml`
  - Updated backend Go setup steps to `1.26.2`
- `.github/workflows/oracle-backend-ci.yml`
  - Updated backend Go setup steps to `1.26.2`
- `.gitignore`
  - Added `report.md` to keep local scan reports out of git history/public repo

## Verification
Executed after patch:
- `pnpm -C oracle-backend run validate` ✅
- `cd oracle-backend && ./scripts/full-scan.sh` ✅
  - `gosec`: 0 issues
  - `govulncheck`: **No vulnerabilities found** in reachable code paths
- `pnpm -C cloudflare-worker run validate` ✅
- `pnpm -C website run test:security` ✅
- `pnpm -C extension run test` ✅ (3242 tests)

## Duplicate check
Searched Issues/PRs for:
- `GO-2026-4947 OR GO-2026-4946 OR GO-2026-4870 OR GO-2026-4866 OR GO-2026-4865`
- `govulncheck crypto/x509 crypto/tls html/template`

No matching existing issue/PR found.

## Commit structure
- `fix(oracle): bump Go toolchain to 1.26.2`
- `ci(oracle): run backend jobs on Go 1.26.2`
- `chore(repo): ignore local scan report output`
