### PR TITLE
feat(website-seo): strengthen site identity schema signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.23.0
@@ -247,7 +247,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Oracle Backend Heavy Test Matrix
         run: pnpm -C oracle-backend test:strict
@@ -296,7 +296,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Migration Bootstrap + Tests
         working-directory: oracle-backend

--- a/.github/workflows/oracle-backend-ci.yml
+++ b/.github/workflows/oracle-backend-ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run Oracle heavy test matrix
         run: pnpm -C oracle-backend test:strict
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run migration bootstrap tests
         working-directory: oracle-backend
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Generate runtime smoke secrets
         run: |
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Ensure no committed Google credential files
         run: |

--- a/oracle-backend/go.mod
+++ b/oracle-backend/go.mod
@@ -1,7 +1,7 @@
 // filepath: oracle-backend/go.mod
 module oracle-backend
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/jackc/pgx/v5 v5.9.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,10 +173,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))
+        version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))
       '@sveltejs/kit':
-        specifier: ^2.56.1
-        version: 2.56.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))
+        specifier: ^2.57.1
+        version: 2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
         version: 7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))
@@ -1471,8 +1471,8 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.56.1':
-    resolution: {integrity: sha512-9hDOl3yUh8UXWt+mN29dbcdrW0vNwPvMqi01y2Mw+ceErNIISh8MeEY7fXT2Dx1CjC/kfsVqrbxw7DifYr4hsg==}
+  '@sveltejs/kit@2.57.1':
+    resolution: {integrity: sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
@@ -2128,6 +2128,9 @@ packages:
 
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
+  devalue@5.7.1:
+    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -4671,11 +4674,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))':
     dependencies:
-      '@sveltejs/kit': 2.56.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@sveltejs/kit@2.56.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))':
+  '@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.1)(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.2)(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
@@ -4683,7 +4686,7 @@ snapshots:
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
-      devalue: 5.6.4
+      devalue: 5.7.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.21
@@ -5374,6 +5377,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   devalue@5.6.4: {}
+
+  devalue@5.7.1: {}
 
   dom-accessibility-api@0.5.16: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.56.1",
+		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@types/d3-geo": "^3.1.0",
 		"@types/d3-scale": "^4.0.9",

--- a/website/src/lib/components/SeoMeta.svelte
+++ b/website/src/lib/components/SeoMeta.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { SITE_URL } from '$lib/config';
+  import { SITE_URL, STORE_LINKS } from '$lib/config';
   import { DEFAULT_LANGUAGE, SITE_LOCALE, SITE_NAME, SOCIAL_IMAGE } from '$lib/seo/site';
 
   export let title: string;
@@ -9,6 +9,7 @@
   export let keywords = '';
   export let type: 'website' | 'article' = 'website';
   export let structuredData: Record<string, unknown> | Array<Record<string, unknown>> | null = null;
+  export let includeSiteIdentityStructuredData = true;
   export let imagePath = SOCIAL_IMAGE.path;
   export let imageAlt = SOCIAL_IMAGE.alt;
   export let imageWidth = SOCIAL_IMAGE.width;
@@ -46,16 +47,69 @@
     return 'image/jpeg';
   }
 
+  function structuredDataKey(item: Record<string, unknown>): string | null {
+    const type = typeof item['@type'] === 'string' ? item['@type'] : '';
+    const id = typeof item['@id'] === 'string' ? item['@id'] : '';
+    if (!type || !id) return null;
+    return `${type}::${id}`;
+  }
+
+  function dedupeStructuredData(items: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+    const deduped: Array<Record<string, unknown>> = [];
+    const seenKeys = new Set<string>();
+
+    for (const item of items) {
+      const key = structuredDataKey(item);
+      if (key) {
+        if (seenKeys.has(key)) continue;
+        seenKeys.add(key);
+      }
+      deduped.push(item);
+    }
+
+    return deduped;
+  }
+
   $: canonical = buildCanonical(SITE_URL, path);
   $: socialImageUrl = buildAbsoluteAssetUrl(SITE_URL, imagePath);
   $: socialImageType = socialImageUrl ? detectImageMimeType(socialImageUrl) : '';
   $: robots = noindex ? 'noindex, nofollow' : 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1';
   $: botPreviewDirectives = noindex ? 'noindex, nofollow' : 'max-image-preview:large, max-snippet:-1, max-video-preview:-1';
-  $: jsonLdItems = structuredData
+  $: pageStructuredDataItems = structuredData
     ? Array.isArray(structuredData)
       ? structuredData
       : [structuredData]
     : [];
+  $: siteIdentityStructuredData = includeSiteIdentityStructuredData
+    ? [
+        {
+          '@context': 'https://schema.org',
+          '@type': 'WebSite',
+          '@id': `${SITE_URL}/#website`,
+          name: siteName,
+          alternateName: 'CQD',
+          url: `${SITE_URL}/`,
+          inLanguage: language,
+          publisher: { '@id': `${SITE_URL}/#organization` }
+        },
+        {
+          '@context': 'https://schema.org',
+          '@type': 'Organization',
+          '@id': `${SITE_URL}/#organization`,
+          name: siteName,
+          alternateName: 'CQD',
+          url: `${SITE_URL}/`,
+          logo: {
+            '@type': 'ImageObject',
+            url: `${SITE_URL}/favicon-512x512.png`,
+            width: 512,
+            height: 512
+          },
+          sameAs: [STORE_LINKS.github, STORE_LINKS.chrome, STORE_LINKS.firefox, STORE_LINKS.edge]
+        }
+      ]
+    : [];
+  $: jsonLdItems = dedupeStructuredData([...pageStructuredDataItems, ...siteIdentityStructuredData]);
   $: jsonLdScriptHtml = jsonLdItems.map((item) => {
     const payload = JSON.stringify(item)
       .replace(/</g, '\\u003c')
@@ -71,6 +125,8 @@
   {#if keywords}
     <meta name="keywords" content={keywords} />
   {/if}
+  <meta name="site_name" content={siteName} />
+  <meta itemprop="name" content={siteName} />
   <meta name="robots" content={robots} />
   <meta name="googlebot" content={botPreviewDirectives} />
   <meta name="bingbot" content={botPreviewDirectives} />


### PR DESCRIPTION
## Summary
- add default WebSite + Organization JSON-LD identity schema on every page via SeoMeta
- dedupe structured data items by @type/@id to avoid duplicate entities
- add explicit site-name meta tags (site_name and itemprop=name) to reinforce brand signals

## Why
- improves Google’s understanding of the site brand/entity for search result site-name rendering
- keeps existing page-level structured data intact while adding consistent global identity

## Validation
- pnpm --filter website build
- pnpm --filter website exec vitest run src/routes/routes.render.test.ts src/routes/layout.shell.test.ts