### PR TITLE
fix(popup): add explicit a11y labels across controls

### DIFF
--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -917,6 +917,7 @@ function App() {
                 </span>
                 {version && (
                   <button
+                    type="button"
                     className={`cqd-brand-version ${getRuleClasses(effectiveRule, seen)}`}
                     aria-label={`Version ${version} - View changelog`}
                     title={getLatestChange(changelogData) ? `Latest: ${getLatestChange(changelogData)}` : "View changelog"}
@@ -1006,6 +1007,8 @@ function App() {
                     <button
                       type="button"
                       className="cqd-cl-retry-btn"
+                      aria-label="Retry loading changelog"
+                      title="Retry loading changelog"
                       onClick={async () => {
                         setChangelogStatus('loading');
                         const retryResult = await fetchChangelogDetailed(true);
@@ -1067,6 +1070,7 @@ function App() {
                   rel="noopener noreferrer"
                   onClick={handleChangelogWebsiteClick}
                   aria-label="Open changelog website"
+                  title="Open changelog website"
                   className="cqd-cl-footer-link cqd-cl-footer-link-secondary"
                 >
                   <span className="cqd-cl-footer-link-content">
@@ -1078,6 +1082,7 @@ function App() {
                   target="_blank" 
                   rel="noopener noreferrer"
                   aria-label="Report an issue or request a feature"
+                  title="Report an issue or request a feature"
                   className="cqd-cl-footer-link"
                 >
                   <span className="cqd-cl-footer-link-content">
@@ -1199,6 +1204,8 @@ function App() {
                               }}
                               tabIndex={0}
                               role="button"
+                              aria-label={`Highlight ${stat.label}: ${stat.value} downloads`}
+                              title={`Highlight ${stat.label}: ${stat.value} downloads`}
                               style={{ cursor: 'pointer' }}
                             >
                               <span
@@ -1232,6 +1239,8 @@ function App() {
                     onClick={handleToggleSettingsCollapse}
                     aria-expanded={!settingsCollapsed}
                     aria-controls="cqd-settings-body"
+                    aria-label={settingsCollapsed ? 'Open extension settings section' : 'Close extension settings section'}
+                    title={settingsCollapsed ? 'Open extension settings section' : 'Close extension settings section'}
                   >
                     <div>
                       <h2 className="cqd-card-title">Extension Settings</h2>
@@ -1329,6 +1338,7 @@ function App() {
                   className="cqd-button cqd-open-classroom-btn"
                   onClick={handleOpenClassroomClick}
                   aria-label="Open Google Classroom in a new tab"
+                  title="Open Google Classroom in a new tab"
                 >
                   <span>Open Google Classroom</span>
                 </button>
@@ -1530,6 +1540,8 @@ function App() {
                   target="_blank"
                   rel="noreferrer"
                   className="cqd-footer-link"
+                  aria-label="Report an issue or suggestion"
+                  title="Report an issue or suggestion"
                 >
                   Report it here
                 </a>

--- a/extension/entrypoints/popup/ErrorBoundary.tsx
+++ b/extension/entrypoints/popup/ErrorBoundary.tsx
@@ -113,6 +113,8 @@ class ErrorBoundary extends Component<Props, State> {
                 <button
                   className="cqd-button cqd-button-primary"
                   onClick={this.handleReportError}
+                  aria-label="Report the extension error"
+                  title="Report the extension error"
                   style={{
                     width: '100%',
                     justifyContent: 'center'
@@ -124,6 +126,8 @@ class ErrorBoundary extends Component<Props, State> {
                 <button
                   className="cqd-button cqd-button-ghost"
                   onClick={this.handleReload}
+                  aria-label="Reload the extension popup"
+                  title="Reload the extension popup"
                   style={{
                     width: '100%',
                     justifyContent: 'center'


### PR DESCRIPTION
## Summary
- add explicit `aria-label` / `title` coverage to remaining popup controls
- add labels for changelog retry action, settings collapse control, legend keyboard-button rows, and footer/report links
- add labels to ErrorBoundary action buttons
- set explicit `type="button"` on version button

## Validation
- `pnpm -C extension run compile`
- `pnpm -C extension run test`
