### PR TITLE
fix(deps): resolve remaining ws and brace-expansion alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
       "eslint>ajv": "8.18.0",
       "undici": "^7.24.0",
       "@isaacs/brace-expansion": ">=5.0.1",
-      "brace-expansion@5.0.4": "5.0.5",
       "minimatch": "^10.2.3",
       "rollup": "^4.59.0",
       "web-ext-run>multimatch": "8.0.0",
@@ -62,7 +61,9 @@
       "flatted": ">=3.4.2",
       "uuid": ">=14.0.0",
       "postcss": ">=8.5.10",
-      "fast-uri": "3.1.2"
+      "fast-uri": "3.1.2",
+      "brace-expansion@>=5.0.0 <5.0.6": "5.0.6",
+      "ws": "8.20.1"
     },
     "packageExtensions": {
       "eslint@10.2.0": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   eslint>ajv: 8.18.0
   undici: ^7.24.0
   '@isaacs/brace-expansion': '>=5.0.1'
-  brace-expansion@5.0.4: 5.0.5
   minimatch: ^10.2.3
   rollup: ^4.59.0
   web-ext-run>multimatch: 8.0.0
@@ -25,6 +24,8 @@ overrides:
   uuid: '>=14.0.0'
   postcss: '>=8.5.10'
   fast-uri: 3.1.2
+  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  ws: 8.20.1
 
 packageExtensionsChecksum: sha256-Mtl/g1U9WZt8ln5xe2MAOO/TzRTYGckF8aPe30g3wls=
 
@@ -1839,8 +1840,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
@@ -3734,20 +3735,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5121,7 +5110,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5749,7 +5738,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6162,7 +6151,7 @@ snapshots:
       sharp: 0.34.5
       undici: 7.24.7
       workerd: 1.20260401.1
-      ws: 8.18.0
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -6170,11 +6159,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 
@@ -7126,9 +7115,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.18.0: {}
-
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- pin `ws` override to `8.20.1`
- replace brace-expansion override with secure range pin:
  - `brace-expansion@>=5.0.0 <5.0.6` -> `5.0.6`
- regenerate lockfile

## Validation
- `pnpm audit` => 0 vulnerabilities
- `pnpm -C website run check`
- `pnpm -C extension run compile`
