### PR TITLE
Signal: block internal email preview pages from search indexing

### DIFF
--- a/website/src/routes/emails/+page.svelte
+++ b/website/src/routes/emails/+page.svelte
@@ -12,6 +12,7 @@
   description="Browser preview of the Classroom Quick Downloader advertisement email."
   path="/emails"
   keywords="classroom quick downloader email, classroom extension email ad"
+  noindex={true}
 />
 
 <section class="emails-page">

--- a/website/src/routes/emails2/+page.svelte
+++ b/website/src/routes/emails2/+page.svelte
@@ -75,6 +75,7 @@
   description="Svelte-native email preview for Classroom Quick Downloader with consistent cross-device rendering."
   path="/emails2"
   keywords="classroom quick downloader email preview, svelte email page"
+  noindex={true}
 />
 
 <section class="emails2-page" aria-label="Classroom Quick Downloader email preview">

--- a/website/src/routes/robots.txt/+server.ts
+++ b/website/src/routes/robots.txt/+server.ts
@@ -16,6 +16,8 @@ Disallow: /uninstall
 Disallow: /404
 Disallow: /overview-editor
 Disallow: /landing2
+Disallow: /emails
+Disallow: /emails2
 
 Sitemap: ${siteUrl}/sitemap.xml
 ${host ? `Host: ${host}\n` : ''}


### PR DESCRIPTION
## 📶 Signal — Website SEO
**Agent:** Signal | **Day:** Wednesday | **Date:** 2024-05-15

---

### 📶 SEO Finding
The internal/draft preview pages (`/emails` and `/emails2`) were not explicitly blocked in `robots.txt` and were missing `noindex` tags. These pages could be crawled and incorrectly indexed by search engines.

### 🎯 Search Impact
Indexing internal preview pages leads to poor quality pages ranking for branded terms, causing a potentially confusing user experience and diluting indexable search signals.

### 🔧 Fix Applied
- Added `Disallow: /emails` and `Disallow: /emails2` to `website/src/routes/robots.txt/+server.ts`.
- Updated `<SeoMeta>` component in both `website/src/routes/emails/+page.svelte` and `website/src/routes/emails2/+page.svelte` to include the `noindex={true}` property.

### ✅ Verification
Ran `pnpm run check`, `pnpm run test`, and `pnpm run build` in the `website` directory. Verified that the `robots.txt` now includes the `Disallow` rules and that the built pages contain the `noindex, nofollow` metadata.

### 📋 Notes
The journal `.jules/signal.md` has been updated with these findings to prevent future preview pages from being inadvertently left without indexing restrictions.

---
*PR created automatically by Jules for task [17398533059738157575](https://jules.google.com/task/17398533059738157575) started by @adhamhaithameid*