### PR TITLE
Refine: Propose tech debt paydown for patches and stale plans

### DIFF
--- a/.jules/refine.md
+++ b/.jules/refine.md
@@ -1,0 +1,10 @@
+
+## 2026-03-12 — High-Priority Tech Debt Suggested
+**Issues Filed:**
+- Refine: 5 accumulated ESLint patches — consolidate or upstream fix
+- Refine: plan.md and refactor-plan.md are stale — convert actionable items to Issues or close
+**Rationale:** The accumulated ESLint patches signal dependency maintenance drift, making upgrades harder and obscuring actual required fixes. The stale plan files clutter the root directory and distract contributors with out-of-date or completed tasks that should be formal GitHub issues instead.
+**Areas for Next Run:**
+- `any` types (55) in extension boundary logic.
+- A significant number of TODOs (100 in extension tests alone) with no associated issue.
+- Disabled Svelte pages (`overview2`, `samples`).

--- a/refine-issue-1.md
+++ b/refine-issue-1.md
@@ -1,0 +1,48 @@
+# Refine: 5 accumulated ESLint patches — consolidate or upstream fix
+
+## ✨ Refine — Tech Debt
+**Agent:** Refine | **Day:** Thursday | **Date:** 2026-03-12
+
+---
+
+### 📦 Debt Category
+Patched Dependencies
+
+### 🔍 Current State
+There are 5 accumulated patch files for `eslint` in the `patches/` directory:
+- `eslint@10.0.0.patch`
+- `eslint@10.0.1.patch`
+- `eslint@10.0.2.patch`
+- `eslint@10.0.3.patch`
+- `eslint@10.2.0.patch`
+
+This is a significant tech debt signal because maintaining multiple patch versions for the same dependency imposes a maintenance burden on every upgrade and clutters the patch list.
+
+### 💡 Proposed Paydown Strategy
+- **Step 1:** Audit the current `eslint` version in use across the repository (e.g., `cloudflare-worker` uses `^10.2.0`). Check if the upstream `eslint` has fixed the issue requiring the patch.
+- **Step 2:** If the upstream fix exists, upgrade `eslint` and delete all 5 patch files.
+- **Step 3:** If the patch is still needed for the current version (`eslint@10.2.0`), delete the 4 older, unused patch files (`10.0.0` through `10.0.3`).
+- **Step 4:** Document the remaining patch (if any) with a comment explaining why it exists and link it to an upstream issue tracking the fix.
+
+### 🎯 Why This Matters Now
+Maintaining multiple patches for the same dependency slows down development velocity when upgrading packages. If patches conflict or the underlying bug is already fixed, it creates unnecessary friction and risk of regressions. Removing stale patches ensures the `patches/` directory only contains active, necessary workarounds.
+
+### 📐 Acceptance Criteria
+- [ ] 0 unused ESLint patch files in `patches/`.
+- [ ] If a patch is still required, only the most recent version (e.g., `eslint@10.2.0.patch`) remains.
+- [ ] Remaining patch (if any) is documented with rationale and an upstream issue link.
+- [ ] CI tests pass after the cleanup.
+
+### 🔧 Technical Context
+- Target directory: `patches/`
+- Command to check patches: `ls patches/eslint*.patch`
+- Verify eslint version in `cloudflare-worker/package.json` and others.
+
+### 📊 Estimated Complexity
+Small (1–2 days) — mostly involves verifying if the patch is still needed, deleting old files, and ensuring tests pass.
+
+### ⚠️ Risks
+Low risk. The primary risk is accidentally removing a patch still needed by the current version, but running the tests after removal will quickly highlight any regressions.
+
+### 🔗 Related
+None yet.

--- a/refine-issue-2.md
+++ b/refine-issue-2.md
@@ -1,0 +1,45 @@
+# Refine: plan.md and refactor-plan.md are stale — convert actionable items to Issues or close
+
+## ✨ Refine — Tech Debt
+**Agent:** Refine | **Day:** Thursday | **Date:** 2026-03-12
+
+---
+
+### 📦 Debt Category
+Stale Plans
+
+### 🔍 Current State
+There are 3 stale or semi-stale plan files sitting in the repository root:
+- `plan.md` (last updated 2026-03-08, regarding Website Reviews Section)
+- `plan2.md` (last updated 2026-03-11, Extension Plan 2 — Practical To-Do Checklist)
+- `refactor-plan.md` (last updated 2026-03-11, CQD Refactor Plan — Current Practical Roadmap)
+
+These files represent intentions that were either completed, superseded, or are partially done. Keeping them in the repository root clutters navigation and creates confusion about what the active plans actually are.
+
+### 💡 Proposed Paydown Strategy
+- **Step 1:** Audit the contents of `plan.md`, `plan2.md`, and `refactor-plan.md` against the current state of the codebase.
+- **Step 2:** For any actionable items still remaining in these plans, extract them into formal, tracked GitHub Issues.
+- **Step 3:** For any completed or outdated items, discard them.
+- **Step 4:** Once all actionable items are converted to Issues, archive these 3 files by either moving them to a `docs/archive/` folder or deleting them entirely.
+
+### 🎯 Why This Matters Now
+Plans sitting in the root of the repository rot quickly. They lose context and fail to represent the actual state of the project. A new contributor (or AI agent) reading these files might attempt to implement outdated architectural patterns or duplicate work. Moving these plans to actionable GitHub Issues keeps the project organized and the root directory clean.
+
+### 📐 Acceptance Criteria
+- [ ] All actionable work from the 3 plan files is converted to tracked GitHub Issues.
+- [ ] `plan.md` is removed from the root directory (archived or deleted).
+- [ ] `plan2.md` is removed from the root directory (archived or deleted).
+- [ ] `refactor-plan.md` is removed from the root directory (archived or deleted).
+
+### 🔧 Technical Context
+- Target files: `plan.md`, `plan2.md`, `refactor-plan.md` in the repo root.
+- Read through them to identify if the described work (e.g., website reviews, extension baseline protection) is done or still pending.
+
+### 📊 Estimated Complexity
+Small (1–2 days) — mostly involves reading documentation, verifying code state, writing up a few GitHub issues, and deleting the files.
+
+### ⚠️ Risks
+Low risk. The main risk is losing important historical context or architectural decisions, which is mitigated by moving them to a `docs/archive/` folder instead of outright deletion if they contain valuable context.
+
+### 🔗 Related
+None yet.


### PR DESCRIPTION
This submission creates two GitHub issues mapping out tech debt identified across the repository per the 'Refine' Thursday tech debt specialist agent's directives. It tackles:
1. 5 accumulated ESLint patches (`patches/eslint*.patch`) that signal a maintenance burden.
2. 3 stale plan files (`plan.md`, `plan2.md`, `refactor-plan.md`) stored in the repository root that clutter the root directory and risk stale context tracking.

Both files are created conforming to the Refine Issue Template strictly without directly modifying any existing source code. The `.jules/refine.md` journal is appended marking completion alongside ideas for the next iteration.

---
*PR created automatically by Jules for task [12111975533481976841](https://jules.google.com/task/12111975533481976841) started by @adhamhaithameid*