### PR TITLE
Vex: update CSP to restrict object-src to 'none'

### DIFF
--- a/.jules/vex.md
+++ b/.jules/vex.md
@@ -3,3 +3,8 @@
 **Finding:** The Content Security Policy in `extension/wxt.config.ts` had `object-src 'self'`, which could allow unsafe plugins to load.
 **Action:** Changed the `object-src` directive to `'none'` to comply with MV3 security best practices and prevent loading unsafe plugins.
 **Learning:** Always ensure `object-src` is strictly `'none'` to tighten the extension's security posture and minimize attack surface.
+
+## 2026-06-07 — tmp path traversal vulnerability
+**Finding:** The `tmp` dependency in `extension/wxt.config.ts` > `web-ext-run` > `tmp` has a high severity Path Traversal vulnerability (CVE-2026-44705, GHSA-ph9p-34f9-6g65).
+**Action:** Logged finding but skipped fixing because Vex is not allowed to modify `node_modules/` or `pnpm-lock.yaml` or dependencies according to Hard Rules.
+**Learning:** Vulnerabilities in WXT build dependencies exist but modifying the lockfile is outside of Vex's jurisdiction.

--- a/.jules/vex.md
+++ b/.jules/vex.md
@@ -1,0 +1,5 @@
+
+## 2026-06-07 — Restrict CSP object-src to 'none'
+**Finding:** The Content Security Policy in `extension/wxt.config.ts` had `object-src 'self'`, which could allow unsafe plugins to load.
+**Action:** Changed the `object-src` directive to `'none'` to comply with MV3 security best practices and prevent loading unsafe plugins.
+**Learning:** Always ensure `object-src` is strictly `'none'` to tighten the extension's security posture and minimize attack surface.

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       'https://oracle.classroom-quick-downloader.com/*',
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://*.google.com https://*.googleapis.com https://*.googleusercontent.com https://cqd-analytics.adhamhaithameid.workers.dev https://oracle.classroom-quick-downloader.com${devConnectSources}; img-src 'self' https://*.google.com https://*.googleusercontent.com data:${devImageSources};`,
+      extension_pages: `script-src 'self'; object-src 'none'; connect-src 'self' https://*.google.com https://*.googleapis.com https://*.googleusercontent.com https://cqd-analytics.adhamhaithameid.workers.dev https://oracle.classroom-quick-downloader.com${devConnectSources}; img-src 'self' https://*.google.com https://*.googleusercontent.com data:${devImageSources};`,
     },
     icons: {
       "16": "icon/16.png",

--- a/vex-issue-1.md
+++ b/vex-issue-1.md
@@ -1,0 +1,22 @@
+## 🔍 Vex — Manifest & Permissions Audit
+**Agent:** Vex | **Day:** Sunday | **Date:** 2026-06-07
+
+---
+
+### 🚨 Severity
+HIGH
+
+### 🔍 Finding
+The `tmp` dependency used by `web-ext-run` (a transitive dependency of `wxt` inside `extension/`) has a high severity Path Traversal vulnerability (`GHSA-ph9p-34f9-6g65`). The vulnerable versions are `<0.2.6`.
+
+### 🎯 Impact
+If left unfixed, this vulnerability could allow directory escapes and arbitrary file creation outside of temporary directories during the build process.
+
+### 🔧 Fix Applied
+None. Vex is prohibited from modifying `node_modules/`, dependency versions, or `pnpm-lock.yaml`.
+
+### ✅ Verification
+N/A
+
+### 📋 Notes
+Logged in `.jules/vex.md`. Another agent (like Sentinel or Refine) with permission to update dependencies should address this.


### PR DESCRIPTION
## 🔍 Vex — Manifest & Permissions Audit
**Agent:** Vex | **Day:** Sunday | **Date:** 2026-06-07

---

### 🚨 Severity
HIGH

### 🔍 Finding
The Content Security Policy defined in `extension/wxt.config.ts` allowed `object-src 'self'`. This could potentially allow the extension to load unsafe plugins or Flash applets, which are not necessary and contradict Manifest V3 security best practices.

### 🎯 Impact
If left unfixed, the extension maintains a broader attack surface than necessary. While Chrome Web Store reviewers generally accept `'self'`, tightening this to `'none'` eliminates a whole class of plugin-based vulnerabilities.

### 🔧 Fix Applied
Changed the `object-src` directive in `content_security_policy.extension_pages` from `'self'` to `'none'` in `extension/wxt.config.ts` to fully restrict plugin loading.

### ✅ Verification
1. `cd extension && pnpm run compile` - Passed
2. `cd extension && pnpm run build` - Passed (verified valid manifest output)
3. `cd extension && pnpm run test` - Passed

### 📋 Notes
The finding, action, and learnings were correctly appended to the agent's journal file: `.jules/vex.md`.

---
*PR created automatically by Jules for task [8945746803110559752](https://jules.google.com/task/8945746803110559752) started by @adhamhaithameid*