### PR TITLE
Shell: handle lastError in tabs.sendMessage

### DIFF
--- a/.jules/shell.md
+++ b/.jules/shell.md
@@ -1,0 +1,4 @@
+## 2024-05-19 — Added missing chrome.runtime.lastError check to chrome.tabs.sendMessage
+**Finding:** Found three `browserApi.tabs.sendMessage` calls in `extension/entrypoints/popup/App.tsx` (in `handleToggleFlag`, `handleToggleV2Engine`, and `handleToggleLegacyEngine`) that were missing the required `chrome.runtime.lastError` check in their callbacks.
+**Action:** Added a callback function `() => { const _ = browserApi.runtime.lastError; }` to all three calls.
+**Learning:** In Chrome extension scripts, any async messaging call like `chrome.tabs.sendMessage` or `chrome.runtime.sendMessage` needs to have its callback handle `chrome.runtime.lastError` or explicitly check it; otherwise, the extension will throw console warnings or unhandled promise rejection errors if the receiving end doesn't exist (like when a content script hasn't been injected or the background worker is dead).

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -715,6 +715,8 @@ function App() {
             type: 'cqd-flag-toggle',
             flag,
             enabled: nextState,
+          }, () => {
+            const _ = browserApi.runtime.lastError;
           });
         }
       });
@@ -759,7 +761,9 @@ function App() {
     if (browserApi?.tabs?.query) {
       browserApi.tabs.query({ active: true, currentWindow: true }, (tabs: any[]) => {
         if (tabs?.[0]?.id) {
-          browserApi.tabs.sendMessage(tabs[0].id, { type: 'cqd-set-mode', mode: nextMode });
+          browserApi.tabs.sendMessage(tabs[0].id, { type: 'cqd-set-mode', mode: nextMode }, () => {
+            const _ = browserApi.runtime.lastError;
+          });
         }
       });
     }
@@ -777,7 +781,9 @@ function App() {
     if (browserApi?.tabs?.query) {
       browserApi.tabs.query({ active: true, currentWindow: true }, (tabs: any[]) => {
         if (tabs?.[0]?.id) {
-          browserApi.tabs.sendMessage(tabs[0].id, { type: 'cqd-set-mode', mode: nextMode });
+          browserApi.tabs.sendMessage(tabs[0].id, { type: 'cqd-set-mode', mode: nextMode }, () => {
+            const _ = browserApi.runtime.lastError;
+          });
         }
       });
     }


### PR DESCRIPTION
## 🐚 Shell — Popup UI
**Agent:** Shell | **Day:** Sunday | **Date:** 2024-05-19

---

### 🚨 Severity
MEDIUM

### 🐚 Finding
Found three `browserApi.tabs.sendMessage` calls in `extension/entrypoints/popup/App.tsx` (in `handleToggleFlag`, `handleToggleV2Engine`, and `handleToggleLegacyEngine`) that were missing the required `chrome.runtime.lastError` check in their callbacks. 

### 🎯 Impact
If a message is sent to a background or content script that isn't listening (e.g. extension loaded but content script not injected yet), the browser throws an "unchecked runtime.lastError" warning in the popup console or raises an unhandled promise rejection.

### 🔧 Fix Applied
Added a callback function `() => { const _ = browserApi.runtime.lastError; }` to all three calls. This accesses the error and silently clears it, which is the standard pattern for fire-and-forget extension messaging.

### ✅ Verification
1. `cd extension && pnpm run compile` - passed
2. `cd extension && pnpm run test` - passed
3. `cd extension && pnpm run build` - passed
4. Inspected code using code review tool - passed

### 📋 Notes
Logged this requirement as a learning to the Shell journal.

---
*PR created automatically by Jules for task [3123696444803483047](https://jules.google.com/task/3123696444803483047) started by @adhamhaithameid*