### PR TITLE
Vault: add timeout to analytics flush fetch to prevent hanging

### DIFF
--- a/extension/entrypoints/utils/analytics/flush.ts
+++ b/extension/entrypoints/utils/analytics/flush.ts
@@ -161,11 +161,15 @@ export async function sendBatchToCloudflare(
     return { success: false, error: 'No URL or empty batch' };
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000); // 10s timeout
+
   try {
     const resp = await fetch(TRACK_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ events, clientBatchId }),
+      signal: controller.signal,
     });
 
     if (resp.status === 429) {
@@ -194,8 +198,13 @@ export async function sendBatchToCloudflare(
       receivedAt: typeof json.receivedAt === 'number' ? json.receivedAt : undefined,
       error: json.error,
     };
-  } catch (err) {
+  } catch (err: any) {
+    if (err.name === 'AbortError') {
+      return { success: false, error: 'Request timeout' };
+    }
     return { success: false, error: String(err) };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## 🔒 Vault — Storage & Analytics
**Agent:** Vault | **Day:** Saturday | **Date:** 2025-02-08

---

### 🚨 Severity
[HIGH]

### 🔒 Finding
The `fetch` call in `sendBatchToCloudflare` inside `extension/entrypoints/utils/analytics/flush.ts` did not have a timeout. It could hang indefinitely if the network drops or the server hangs, tying up resources.

### 🎯 Impact
Without a timeout, a hanging request could indefinitely delay the analytics queue, block subsequent flushes, and consume resources unnecessarily.

### 🔧 Fix Applied
Added an `AbortController` to the `fetch` request, paired with a `setTimeout` of 10 seconds (10000ms), and added a `finally` block to call `clearTimeout` to prevent dangling timeouts. The `catch` block now specifically handles the `AbortError`.

### ✅ Verification
1. Run `cd extension && pnpm run compile`
2. Run `cd extension && pnpm run test`
3. Run `cd extension && pnpm run build`

### 📋 Notes
This fix ensures that the `fetch` request will time out after 10 seconds and return a clean error without crashing or hanging indefinitely.

---
*PR created automatically by Jules for task [10038182486116179815](https://jules.google.com/task/10038182486116179815) started by @adhamhaithameid*