### PR TITLE
fix: consolidate low-risk draft PR fixes

### DIFF
--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -265,7 +265,12 @@ export async function verifySessionToken(
     
     if (!isValid) return false;
     
-    const payload: SessionPayload = JSON.parse(atob(payloadB64));
+    let payload: SessionPayload;
+    try {
+      payload = JSON.parse(atob(payloadB64));
+    } catch {
+      return false;
+    }
     
     // Check expiration
     if (Date.now() > payload.exp) return false;
@@ -838,11 +843,16 @@ async function checkLoginAllowlist(
   if (!checkRes.ok) {
     throw new Error(`ip-allowlist endpoint returned ${checkRes.status}`);
   }
-  const checkData = await checkRes.json() as {
+  let checkData: {
     allowed?: unknown;
     enabled?: unknown;
     stepUpBypassEnabled?: unknown;
   };
+  try {
+    checkData = await checkRes.json();
+  } catch {
+    throw new Error("ip-allowlist returned invalid JSON");
+  }
   if (typeof checkData.allowed !== "boolean") {
     throw new Error("ip-allowlist payload missing allowed boolean");
   }
@@ -1171,7 +1181,15 @@ async function handleDashboard(request: Request, env: WorkerEnv): Promise<Respon
     );
   }
 
-  const stats = (await statsRes.json()) as StatsResponse;
+  let stats: StatsResponse;
+  try {
+    stats = await statsRes.json() as StatsResponse;
+  } catch {
+    return new Response(
+      "Failed to load stats from Durable Object (Invalid JSON).",
+      { status: 500 }
+    );
+  }
   const nonce = generateCspNonce();
   const html = renderDashboard(stats, nonce);
 
@@ -1492,7 +1510,12 @@ async function fetchDoWebsiteStatus(env: WorkerEnv): Promise<Record<string, unkn
   if (!res.ok) {
     throw new Error(`do_status_http_${res.status}`);
   }
-  const payload = await res.json();
+  let payload: unknown;
+  try {
+    payload = await res.json();
+  } catch {
+    throw new Error("do_status_invalid_json");
+  }
   if (!payload || typeof payload !== "object") {
     throw new Error("do_status_invalid_payload");
   }
@@ -2348,7 +2371,12 @@ async function fetchOracleSnapshotPayload(env: WorkerEnv): Promise<Record<string
   if (!upstream.ok) {
     throw new Error(`oracle_http_${upstream.status}`);
   }
-  const payload = await upstream.json();
+  let payload: unknown;
+  try {
+    payload = await upstream.json();
+  } catch {
+    throw new Error("oracle_invalid_json");
+  }
   if (!payload || typeof payload !== "object") {
     throw new Error("oracle_invalid_snapshot");
   }

--- a/cloudflare-worker/tests/dashboard.test.ts
+++ b/cloudflare-worker/tests/dashboard.test.ts
@@ -199,6 +199,21 @@ describe("Dashboard login rendering", () => {
     expect(html).not.toContain(`<img src=x onerror=alert("xss")>`);
     expect(html).toContain("</form>");
   });
+
+  it("renders key login page elements properly", () => {
+    const html = renderSimpleLoginPage();
+    expect(html).toContain('class="login-card"');
+    expect(html).toContain('id="password-input"');
+    expect(html).toContain('type="password"');
+    expect(html).toContain("CQD Analytics Admin");
+    expect(html).not.toContain('class="login-error"');
+  });
+
+  it("conditionally renders the error block if errorMessage is provided", () => {
+    const html = renderSimpleLoginPage("Invalid password");
+    expect(html).toContain('class="login-error"');
+    expect(html).toContain("Invalid password");
+  });
 });
 
 describe("Dashboard security rendering", () => {

--- a/cloudflare-worker/tests/ip_utils.test.ts
+++ b/cloudflare-worker/tests/ip_utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { isValidIpv4 } from "../src/ip_utils";
+
+describe("isValidIpv4", () => {
+  it("should return true for valid IPv4 addresses", () => {
+    expect(isValidIpv4("192.168.1.1")).toBe(true);
+    expect(isValidIpv4("0.0.0.0")).toBe(true);
+    expect(isValidIpv4("255.255.255.255")).toBe(true);
+    expect(isValidIpv4("10.0.0.1")).toBe(true);
+    expect(isValidIpv4("127.0.0.1")).toBe(true);
+  });
+
+  it("should return false for IPs with incorrect number of octets", () => {
+    expect(isValidIpv4("192.168.1")).toBe(false);
+    expect(isValidIpv4("192.168.1.1.1")).toBe(false);
+    expect(isValidIpv4("192")).toBe(false);
+    expect(isValidIpv4("")).toBe(false);
+  });
+
+  it("should return false for IPs with non-numeric characters", () => {
+    expect(isValidIpv4("192.168.1.a")).toBe(false);
+    expect(isValidIpv4("192.168.1. ")).toBe(false);
+    expect(isValidIpv4("192.168.1.-1")).toBe(false);
+    expect(isValidIpv4("192.168.1.1a")).toBe(false);
+  });
+
+  it("should return false for IPs with empty octets", () => {
+    expect(isValidIpv4("192.168..1")).toBe(false);
+    expect(isValidIpv4(".168.1.1")).toBe(false);
+    expect(isValidIpv4("192.168.1.")).toBe(false);
+  });
+
+  it("should return false for IPs with out-of-bounds octets", () => {
+    expect(isValidIpv4("256.0.0.0")).toBe(false);
+    expect(isValidIpv4("192.168.1.256")).toBe(false);
+    expect(isValidIpv4("192.168.256.1")).toBe(false);
+    expect(isValidIpv4("192.256.1.1")).toBe(false);
+    expect(isValidIpv4("999.1.1.1")).toBe(false);
+  });
+
+  it("should return false for IPs with leading zeros", () => {
+    expect(isValidIpv4("192.168.01.1")).toBe(false);
+    expect(isValidIpv4("192.168.1.00")).toBe(false);
+    expect(isValidIpv4("01.0.0.0")).toBe(false);
+    expect(isValidIpv4("192.0168.1.1")).toBe(false);
+  });
+});

--- a/cloudflare-worker/tests/release-notes.test.ts
+++ b/cloudflare-worker/tests/release-notes.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeReleaseEntries } from "../src/release-notes";
+
+describe("sanitizeReleaseEntries", () => {
+  it("returns empty array for empty input", () => {
+    expect(sanitizeReleaseEntries([])).toEqual([]);
+  });
+
+  it("filters out invalid entries (null, undefined, non-objects)", () => {
+    const entries = [
+      null,
+      undefined,
+      "string",
+      123,
+      true,
+      [], // array is an object, but handled internally (coerced defaults)
+      { version: "1.0.0" }
+    ];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized.length).toBe(2);
+    // [] becomes an empty object effectively
+    expect(sanitized[0].version).toBe("Unknown");
+    expect(sanitized[1].version).toBe("1.0.0");
+  });
+
+  it("applies fallbacks for missing or invalid fields", () => {
+    const entries = [{}];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized).toEqual([{
+      id: "Unknown-0",
+      version: "Unknown",
+      date: new Date(0).toISOString(),
+      changes: []
+    }]);
+  });
+
+  it("trims strings and uses provided valid values", () => {
+    const entries = [{
+      id: "  my-id  ",
+      version: "  2.0.0  ",
+      date: "2024-01-01T00:00:00.000Z",
+      changes: ["  change 1  ", "change 2", "  "]
+    }];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized).toEqual([{
+      id: "my-id",
+      version: "2.0.0",
+      date: "2024-01-01T00:00:00.000Z",
+      changes: ["change 1", "change 2"]
+    }]);
+  });
+
+  it("sorts entries descending by date", () => {
+    const entries = [
+      { id: "1", date: "2023-01-01T00:00:00.000Z" },
+      { id: "2", date: "2025-01-01T00:00:00.000Z" },
+      { id: "3", date: "2024-01-01T00:00:00.000Z" },
+      { id: "4" } // Missing date -> 1970
+    ];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized.map(e => e.id)).toEqual(["2", "3", "1", "4"]);
+  });
+
+  it("coerces invalid dates to epoch", () => {
+    const entries = [
+      { date: "not-a-date" },
+      { date: "   " }
+    ];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized[0].date).toBe(new Date(0).toISOString());
+    expect(sanitized[1].date).toBe(new Date(0).toISOString());
+  });
+
+  it("handles changes arrays correctly", () => {
+    const entries = [{
+      changes: [
+        null,
+        "valid",
+        123,
+        "   ",
+        "another valid"
+      ]
+    }];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized[0].changes).toEqual(["valid", "another valid"]);
+  });
+
+  it("slices changes to a maximum of 32 entries", () => {
+    const manyChanges = Array.from({ length: 40 }, (_, i) => `change ${i}`);
+    const entries = [{ changes: manyChanges }];
+    const sanitized = sanitizeReleaseEntries(entries);
+    expect(sanitized[0].changes.length).toBe(32);
+    expect(sanitized[0].changes[31]).toBe("change 31");
+  });
+});

--- a/extension/entrypoints/background/index.ts
+++ b/extension/entrypoints/background/index.ts
@@ -148,6 +148,7 @@ export default defineBackground(() => {
 
   // 0) Icon update from content scripts
   chrome.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== chrome.runtime.id) return false;
     if (message?.type === 'CQD_UPDATE_ICON' && sender.tab?.id != null) {
       updateTabIcon(sender.tab.id, sender.tab.url);
       return false;
@@ -156,6 +157,7 @@ export default defineBackground(() => {
 
   // 0b) Student Work resolver bridge relay (runtime-authenticated, tab-scoped)
   chrome.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== chrome.runtime.id) return false;
     if (!isStudentWorkResolvePublishMessage(message)) return false;
     if (sender.tab?.id == null) return false;
 
@@ -175,6 +177,7 @@ export default defineBackground(() => {
 
   // 1) Messages from drive_bypass.content.ts
   chrome.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== chrome.runtime.id) return false;
     if (!message || !sender.tab || sender.tab.id == null) return false;
 
     const tabId = sender.tab.id;
@@ -398,12 +401,14 @@ export default defineBackground(() => {
 
   // 4) CQD_DOWNLOAD handler
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (sender.id !== chrome.runtime.id) return false;
     if (!message || message.type !== 'CQD_DOWNLOAD') return false;
     return handleDownloadRequest(message, sender, sendResponse);
   });
 
   // 5) CQD_CANCEL_DOWNLOAD handler
-  chrome.runtime.onMessage.addListener((message) => {
+  chrome.runtime.onMessage.addListener((message, sender) => {
+    if (sender.id !== chrome.runtime.id) return false;
     if (!message || message.type !== 'CQD_CANCEL_DOWNLOAD') return false;
 
     const requestId = message.requestId as string | undefined;

--- a/extension/src/download-all/cancel-handler.ts
+++ b/extension/src/download-all/cancel-handler.ts
@@ -105,7 +105,7 @@ export function handleCancelAllClick(group: GroupState): void {
     file.inProgress = false;
     file.failed = true;
 
-    const requestId = (primary.dataset as any).cqdRequestId;
+    const requestId = primary.dataset['cqdRequestId'];
     if (requestId && typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
       try {
         chrome.runtime.sendMessage({ type: 'CQD_CANCEL_DOWNLOAD', requestId });

--- a/extension/src/download-all/group-manager.ts
+++ b/extension/src/download-all/group-manager.ts
@@ -133,7 +133,7 @@ export function findGroupRoot(btn: HTMLElement): HTMLElement | null {
  * Get canonical file key from button data.
  */
 export function getCanonicalFileKey(btn: HTMLButtonElement): string {
-  const ds = btn.dataset as any;
+  const ds = btn.dataset;
   const explicitFileKey = (ds.cqdFileKey || '').trim();
   if (explicitFileKey) return explicitFileKey;
   const url = ds.cqdUrl || '';

--- a/extension/src/download-all/refresh.ts
+++ b/extension/src/download-all/refresh.ts
@@ -105,7 +105,7 @@ export function updateGroupState(group: GroupState): void {
     for (const b of file.buttons) {
       if (!b.isConnected) continue;
       const cls = b.classList;
-      const ds = b.dataset as any;
+      const ds = b.dataset;
       const isLoading = cls.contains('cqd-loading') || cls.contains('cqd-trying');
       const isSuccess = cls.contains('cqd-success') || ds.cqdAllDone === 'true';
       const isError = cls.contains('cqd-error');

--- a/extension/src/download-all/utils.ts
+++ b/extension/src/download-all/utils.ts
@@ -16,7 +16,7 @@ export function getSingleButtonState(btn: HTMLButtonElement): ButtonState {
   if (cls.contains('cqd-error')) return 'error';
   if (cls.contains('cqd-cancelled')) return 'cancelled';
   if (cls.contains('cqd-cancel')) return 'cancel';
-  if ((btn.dataset as any).cqdAllDone === 'true') return 'success';
+  if (btn.dataset['cqdAllDone'] === 'true') return 'success';
   return 'idle';
 }
 

--- a/extension/src/student_work/button.ts
+++ b/extension/src/student_work/button.ts
@@ -34,7 +34,7 @@ let statusBridgeSetup = false;
 function findStudentWorkButtonByRequestId(requestId: string): HTMLButtonElement | null {
   const buttons = document.querySelectorAll<HTMLButtonElement>('.cqd-download-btn[data-cqd-sw="true"]');
   for (const button of buttons) {
-    if ((button.dataset as any).cqdRequestId === requestId) return button;
+    if (button.dataset['cqdRequestId'] === requestId) return button;
   }
   return null;
 }
@@ -116,15 +116,15 @@ function ensureStudentWorkStatusBridge(): void {
         pendingButtons.delete(requestId);
         if (button.classList.contains('cqd-cancelled')) {
           try {
-            delete (button.dataset as any).cqdRequestId;
+            delete button.dataset['cqdRequestId'];
           } catch {
             // Ignore dataset cleanup errors.
           }
           return;
         }
         try {
-          delete (button.dataset as any).cqdRequestId;
-          (button.dataset as any).cqdAllDone = 'true';
+          delete button.dataset['cqdRequestId'];
+          button.dataset['cqdAllDone'] = 'true';
         } catch {
           // Ignore dataset cleanup errors.
         }
@@ -143,7 +143,7 @@ function ensureStudentWorkStatusBridge(): void {
 
         pendingButtons.delete(requestId);
         try {
-          delete (button.dataset as any).cqdRequestId;
+          delete button.dataset['cqdRequestId'];
         } catch {
           // Ignore dataset cleanup errors.
         }
@@ -173,11 +173,11 @@ function armDownloadWatchdog(button: HTMLButtonElement): void {
   const timerId = window.setTimeout(() => {
     downloadWatchdogTimers.delete(button);
     if (!isButtonAwaitingTerminalStatus(button)) return;
-    const requestId = ((button.dataset as any).cqdRequestId || '').trim();
+    const requestId = (button.dataset['cqdRequestId'] || '').trim();
     if (requestId) {
       pendingButtons.delete(requestId);
       try {
-        delete (button.dataset as any).cqdRequestId;
+        delete button.dataset['cqdRequestId'];
       } catch {
         // Ignore dataset cleanup errors.
       }

--- a/extension/src/v2/decision/exclusion-engine.ts
+++ b/extension/src/v2/decision/exclusion-engine.ts
@@ -589,16 +589,23 @@ export function isInExcludedArea(element: HTMLElement): boolean {
   return false;
 }
 
+let cachedUserContentSelectors: string[] | null = null;
+
 /**
  * Get all user-content exclusion selectors.
  *
  * Used to build a visibility cache — collect these once per scan,
  * then check text nodes against them.
+ * Caches the result to avoid redundant map/filter memory allocations.
  */
 export function getUserContentSelectors(): string[] {
-  return EXCLUSION_RULES
+  if (cachedUserContentSelectors) {
+    return cachedUserContentSelectors;
+  }
+  cachedUserContentSelectors = EXCLUSION_RULES
     .filter(r => r.type === 'selector' && r.category === 'user_content')
     .map(r => r.pattern as string);
+  return cachedUserContentSelectors;
 }
 
 /**

--- a/extension/src/v2/render/download-all-renderer.ts
+++ b/extension/src/v2/render/download-all-renderer.ts
@@ -148,35 +148,41 @@ export function updateDownloadAllUI(
 
   switch (state) {
     case 'idle':
+      button.disabled = false;
       if (label) label.textContent = 'Download All';
       if (countEl) countEl.textContent = String(progress.total);
       break;
 
     case 'downloading':
+      button.disabled = true;
       button.classList.add('cqd-loading');
       if (label) label.textContent = `Downloading`;
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
       break;
 
     case 'success':
+      button.disabled = true;
       button.classList.add('cqd-success');
       if (label) label.textContent = 'Downloaded';
       if (countEl) countEl.textContent = `${progress.total}`;
       break;
 
     case 'error':
+      button.disabled = true;
       button.classList.add('cqd-error');
       if (label) label.textContent = 'Failed';
       if (countEl) countEl.textContent = `${progress.failed}`;
       break;
 
     case 'partial':
+      button.disabled = true;
       button.classList.add('cqd-error');
       if (label) label.textContent = 'Partial';
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
       break;
 
     case 'cancelled':
+      button.disabled = true;
       button.classList.add('cqd-cancelled');
       if (label) label.textContent = 'Cancelled';
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
@@ -197,6 +203,7 @@ export function resetDownloadAllButton(
   button: HTMLButtonElement,
   fileCount: number,
 ): void {
+  button.disabled = false;
   button.classList.remove(
     'cqd-loading',
     'cqd-success',

--- a/extension/tests/background-index.test.ts
+++ b/extension/tests/background-index.test.ts
@@ -265,6 +265,7 @@ describe('background/index', () => {
           },
         },
         {
+          id: chrome.runtime.id,
           tab: { id: 55, url: 'https://classroom.google.com/c/C/a/A/submissions' },
           url: 'https://classroom.google.com/g/tg/a/b/c?cqd_sw_req=relay-req-1&cqd_sw_mode=iframe',
         },

--- a/extension/tests/v2-download-all-renderer.test.ts
+++ b/extension/tests/v2-download-all-renderer.test.ts
@@ -149,6 +149,7 @@ describe('Download All Renderer: UI Updates', () => {
     updateDownloadAllUI(btn, progress);
 
     expect(btn.classList.contains('cqd-loading')).toBe(true);
+    expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Downloading');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('1/3');
   });
@@ -164,6 +165,7 @@ describe('Download All Renderer: UI Updates', () => {
     updateDownloadAllUI(btn, progress);
 
     expect(btn.classList.contains('cqd-success')).toBe(true);
+    expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Downloaded');
   });
 
@@ -178,8 +180,26 @@ describe('Download All Renderer: UI Updates', () => {
     updateDownloadAllUI(btn, progress);
 
     expect(btn.classList.contains('cqd-error')).toBe(true);
+    expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Failed');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('3');
+  });
+
+  it('updateDownloadAllUI sets partial state', () => {
+    const btn = mockDownloadAllButton();
+    document.body.appendChild(btn);
+
+    const progress = createProgress(3);
+    progress.completed = 2;
+    progress.failed = 1;
+    progress.pending = 0;
+
+    updateDownloadAllUI(btn, progress);
+
+    expect(btn.classList.contains('cqd-error')).toBe(true);
+    expect(btn.disabled).toBe(true);
+    expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Partial');
+    expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('2/3');
   });
 
   it('updateDownloadAllUI sets cancelled state', () => {
@@ -193,6 +213,7 @@ describe('Download All Renderer: UI Updates', () => {
     updateDownloadAllUI(btn, progress);
 
     expect(btn.classList.contains('cqd-cancelled')).toBe(true);
+    expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Cancelled');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('1/3');
   });
@@ -224,6 +245,7 @@ describe('Download All Renderer: Reset', () => {
 
   it('resetDownloadAllButton restores idle state', () => {
     const btn = mockDownloadAllButton();
+    btn.disabled = true;
     btn.classList.add('cqd-success');
     btn.querySelector('.cqd-v2-label')!.textContent = 'Downloaded';
     btn.querySelector('.cqd-v2-count')!.textContent = '5';
@@ -231,6 +253,7 @@ describe('Download All Renderer: Reset', () => {
 
     resetDownloadAllButton(btn, 3);
 
+    expect(btn.disabled).toBe(false);
     expect(btn.classList.contains('cqd-success')).toBe(false);
     expect(btn.classList.contains('cqd-loading')).toBe(false);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Download All');

--- a/extension/tests/v2-route-classifier.test.ts
+++ b/extension/tests/v2-route-classifier.test.ts
@@ -75,6 +75,29 @@ describe('classifyRoute', () => {
   });
 
   // Unknown routes
+// Relative paths / pathnames only
+  it('handles relative pathnames correctly', () => {
+    expect(classifyRoute('/c/MTIz')).toBe('stream');
+    expect(classifyRoute('/w/MTIz/t/all')).toBe('classwork_list');
+    expect(classifyRoute('not-a-valid-url')).toBe('unknown');
+  });
+
+  // Ignore patterns
+  it('returns unknown for ignored patterns', () => {
+    // People tab
+    expect(classifyRoute('https://classroom.google.com/r/MTIz/sort-last-name')).toBe('unknown');
+    // Grades
+    expect(classifyRoute('https://classroom.google.com/g/MTIz')).toBe('unknown');
+    expect(classifyRoute('https://classroom.google.com/u/0/g/MTIz')).toBe('unknown');
+    // Notifications
+    expect(classifyRoute('https://classroom.google.com/notifications')).toBe('unknown');
+    // Home
+    expect(classifyRoute('https://classroom.google.com/h')).toBe('unknown');
+    expect(classifyRoute('https://classroom.google.com/h/')).toBe('unknown');
+    // Login page
+    expect(classifyRoute('https://accounts.google.com/ServiceLogin')).toBe('unknown');
+  });
+
   it('returns unknown for unrecognized Classroom paths', () => {
     expect(classifyRoute('https://classroom.google.com/settings')).toBe('unknown');
   });

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
       'https://oracle.classroom-quick-downloader.com/*',
     ],
     content_security_policy: {
-      extension_pages: `script-src 'self'; object-src 'self'; connect-src 'self' https://*.google.com https://*.googleapis.com https://*.googleusercontent.com https://cqd-analytics.adhamhaithameid.workers.dev https://oracle.classroom-quick-downloader.com${devConnectSources}; img-src 'self' https://*.google.com https://*.googleusercontent.com data:${devImageSources};`,
+      extension_pages: `script-src 'self'; object-src 'none'; connect-src 'self' https://*.google.com https://*.googleapis.com https://*.googleusercontent.com https://cqd-analytics.adhamhaithameid.workers.dev https://oracle.classroom-quick-downloader.com${devConnectSources}; img-src 'self' https://*.google.com https://*.googleusercontent.com data:${devImageSources};`,
     },
     icons: {
       "16": "icon/16.png",

--- a/website/src/routes/faq/+page.svelte
+++ b/website/src/routes/faq/+page.svelte
@@ -529,6 +529,7 @@
                   type="button"
                   on:click={() => toggle(item.id)}
                   aria-expanded={openIds.has(item.id)}
+                  aria-controls={`faq-answer-${item.id}`}
                 >
                   <div class="fq-question">
                     <span class="fq-q-text">{item.q}</span>
@@ -544,7 +545,7 @@
                     </span>
                   </div>
                   {#if openIds.has(item.id)}
-                    <p class="fq-answer">{item.a}</p>
+                    <p id={`faq-answer-${item.id}`} class="fq-answer">{item.a}</p>
                   {/if}
                 </button>
               {/each}


### PR DESCRIPTION
## Summary

Fresh minimal branch from current `main` that consolidates low-risk fixes from stale draft PRs without carrying old workflow/go.mod/package-lock churn.

Includes:
- CSP hardening: `object-src 'none'`
- FAQ accordion `aria-controls` linkage
- background sender validation for runtime messages
- Cloudflare Worker JSON parse guards
- Download All disabled-state handling and tests
- exclusion selector caching
- dataset `any` cleanup
- small Cloudflare Worker and extension test coverage additions

Supersedes stale draft PRs: #571, #567, #577, #578, #582, #593, #583, #560, #561, #562, #563.

## Verification

- `pnpm -C cloudflare-worker run validate`
- `pnpm -C cloudflare-worker test`
- `pnpm -C extension test`
- `pnpm -C website check`
- `pnpm -C website test`

## Notes

I intentionally did not include #564 because the Oracle handler test path was too slow/hanging locally and should stay as a separate Oracle-only pass.
