### PR TITLE
fix: consolidate safe draft PR fixes

### DIFF
--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -405,6 +405,7 @@ function redirectWithCookies(location: string, cookies: string[]): Response {
 }
 
 const HTML_SECURITY_HEADERS = {
+  "strict-transport-security": "max-age=31536000; includeSubDomains",
   "x-content-type-options": "nosniff",
   "x-frame-options": "DENY",
   "referrer-policy": "strict-origin-when-cross-origin",

--- a/cloudflare-worker/tests/headers.test.ts
+++ b/cloudflare-worker/tests/headers.test.ts
@@ -57,6 +57,7 @@ function buildEnv(): Env {
 }
 
 function expectSecurityHeaders(response: Response): void {
+  expect(response.headers.get("strict-transport-security")).toBe("max-age=31536000; includeSubDomains");
   expect(response.headers.get("content-security-policy")).toContain("default-src 'self'");
   expect(response.headers.get("x-content-type-options")).toBe("nosniff");
   expect(response.headers.get("x-frame-options")).toBe("DENY");
@@ -79,4 +80,3 @@ describe("HTML security headers", () => {
     expectSecurityHeaders(res);
   });
 });
-

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -1606,6 +1606,8 @@ export function ToggleRow({
       >
         <input
           type="checkbox"
+          role="switch"
+          aria-checked={checked}
           checked={checked}
           disabled={isDisabled}
           onChange={handleChange}

--- a/extension/entrypoints/utils/analytics/flush.ts
+++ b/extension/entrypoints/utils/analytics/flush.ts
@@ -161,11 +161,15 @@ export async function sendBatchToCloudflare(
     return { success: false, error: 'No URL or empty batch' };
   }
 
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
   try {
     const resp = await fetch(TRACK_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ events, clientBatchId }),
+      signal: controller.signal,
     });
 
     if (resp.status === 429) {
@@ -195,7 +199,12 @@ export async function sendBatchToCloudflare(
       error: json.error,
     };
   } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      return { success: false, error: 'Request timeout' };
+    }
     return { success: false, error: String(err) };
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/extension/tests/analytics-flush-runtime.test.ts
+++ b/extension/tests/analytics-flush-runtime.test.ts
@@ -140,6 +140,18 @@ describe('analytics flush runtime', () => {
     fetchMock.mockRejectedValueOnce(new Error('network down'));
     expect(await mod.sendBatchToCloudflare([makeEvent()], 'c5')).toMatchObject({ success: false });
 
+    fetchMock.mockImplementationOnce((_url, init) => new Promise((_resolve, reject) => {
+      const signal = (init as RequestInit).signal;
+      signal?.addEventListener('abort', () => {
+        const abortError = new Error('aborted');
+        abortError.name = 'AbortError';
+        reject(abortError);
+      });
+    }));
+    const timeoutResult = mod.sendBatchToCloudflare([makeEvent()], 'c6');
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(await timeoutResult).toMatchObject({ success: false, error: 'Request timeout' });
+
     expect(await mod.sendBatchToCloudflare([], 'empty')).toMatchObject({ success: false });
   });
 

--- a/extension/tests/popup-toggle-switch.test.ts
+++ b/extension/tests/popup-toggle-switch.test.ts
@@ -51,6 +51,8 @@ describe('popup toggle switch accessibility', () => {
     expect(switchLabel?.getAttribute('tabindex')).toBeNull();
 
     expect(input).not.toBeNull();
+    expect(input?.getAttribute('role')).toBe('switch');
+    expect(input?.getAttribute('aria-checked')).toBe('false');
     expect(input?.getAttribute('aria-label')).toBe('Enable Extension');
     expect(input?.checked).toBe(false);
   });

--- a/oracle-backend/cmd/app/middleware.go
+++ b/oracle-backend/cmd/app/middleware.go
@@ -210,6 +210,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 			scriptSrc += " 'nonce-" + nonce + "'"
 			styleSrc += " 'nonce-" + nonce + "'"
 		}
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Referrer-Policy", "no-referrer")

--- a/oracle-backend/cmd/app/middleware_csp_test.go
+++ b/oracle-backend/cmd/app/middleware_csp_test.go
@@ -216,6 +216,21 @@ func TestSecurityHeaders_PermissionsPolicy(t *testing.T) {
 	}
 }
 
+func TestSecurityHeaders_StrictTransportSecurity(t *testing.T) {
+	handler := securityHeadersMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	hsts := rr.Header().Get("Strict-Transport-Security")
+	if hsts != "max-age=31536000; includeSubDomains" {
+		t.Fatalf("expected Strict-Transport-Security header to be set, got %q", hsts)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // CSP nonce uniqueness
 // ---------------------------------------------------------------------------

--- a/website/src/lib/components/LoadingScreen.svelte
+++ b/website/src/lib/components/LoadingScreen.svelte
@@ -38,7 +38,7 @@
     <div class="ld-backdrop"></div>
     <div class="ld-center">
       <div class="ld-logo-ring">
-        <img src={logo} alt="CQD" class="ld-logo" />
+        <img src={logo} alt="CQD" class="ld-logo" width="28" height="28" loading="eager" decoding="async" />
         <svg class="ld-spinner" viewBox="0 0 56 56" fill="none">
           <circle cx="28" cy="28" r="26" stroke="rgba(26,139,85,0.12)" stroke-width="3" />
           <circle cx="28" cy="28" r="26" stroke="url(#ld-grad)" stroke-width="3" stroke-linecap="round" stroke-dasharray="120 200" class="ld-arc" />

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -155,7 +155,7 @@
   <header class="l2-nav-shell">
     <div class="l2-nav-inner l2-nav-fullwidth">
       <a href="{base}/" class="l2-nav-brand">
-        <img src={logo} alt="Classroom Quick Downloader" class="l2-nav-logo" />
+        <img src={logo} alt="Classroom Quick Downloader" class="l2-nav-logo" width="42" height="36" loading="eager" decoding="async" />
         <span class="l2-nav-brand-text">Classroom Quick Downloader</span>
       </a>
 
@@ -252,7 +252,7 @@
     <div class="l2-wrap l2-footer-inner">
       <div class="l2-footer-left">
         <a href="https://github.com/adhamhaithameid" target="_blank" rel="noopener noreferrer" class="l2-footer-credit-link">
-          <img src="https://github.com/adhamhaithameid.png?size=22" alt="Adham Haitham" class="l2-footer-avatar" />
+          <img src="https://github.com/adhamhaithameid.png?size=22" alt="Adham Haitham" class="l2-footer-avatar" width="20" height="20" loading="lazy" decoding="async" />
           Built by <strong>Adham Haitham</strong>
         </a>
         <span class="l2-footer-sep">•</span>


### PR DESCRIPTION
Consolidates only the low-risk, clean parts from remaining draft PRs without lockfile/toolchain/workflow churn.\n\nIncluded:\n- Add switch semantics to popup toggle inputs.\n- Add timeout handling to analytics Cloudflare flush requests.\n- Add HSTS headers to Cloudflare Worker HTML responses and Oracle backend security headers.\n- Add explicit image dimensions/loading hints for shared website chrome/loading images.\n\nSupersedes the relevant scoped pieces of #573, #568, #580, and #600.\n\nLocal validation:\n- pnpm -C extension test -- popup-toggle-switch analytics-flush-runtime\n- pnpm -C cloudflare-worker test -- headers\n- pnpm -C website check\n- pnpm -C website test\n\nNote: local oracle-backend Go test attempts hung during dependency/package discovery after downloading modernc.org/sqlite; GitHub CI should validate the Oracle test matrix.