### PR TITLE
Flare: sanitise Oracle error responses to prevent leaking internal details

### DIFF
--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -2176,13 +2176,16 @@ async function handleOraclePublicWebsiteProxy(request: Request, env: WorkerEnv):
     }
 
     const responseHeaders = new Headers({
-      "content-type": upstream.headers.get("content-type") || "application/json; charset=utf-8",
+      "content-type": upstream.ok ? (upstream.headers.get("content-type") || "application/json; charset=utf-8") : "application/json; charset=utf-8",
     });
     const cacheControl = upstream.headers.get("cache-control");
-    if (cacheControl) responseHeaders.set("cache-control", cacheControl);
+    if (cacheControl && upstream.ok) responseHeaders.set("cache-control", cacheControl);
+
+    const responseBody = upstream.ok ? body : JSON.stringify({ ok: false, error: "upstream_error" });
+
     return withCors(
       request,
-      new Response(body, {
+      new Response(responseBody, {
         status: upstream.status,
         headers: responseHeaders,
       }),


### PR DESCRIPTION
## 🌩️ Flare — Cloudflare Worker Security & Performance
**Agent:** Flare | **Day:** Monday | **Date:** 2026-06-15

---

### 🚨 Severity
MEDIUM

### 🌩️ Finding
`cloudflare-worker/src/index.ts` - `handleOraclePublicWebsiteProxy` proxies upstream Oracle error response bodies verbatim to the client without fallback.

### 🎯 Impact
Leaking internal Oracle backend error details, topology, or stack traces directly to external clients.

### 🔧 Fix Applied
Modified `handleOraclePublicWebsiteProxy` to check `upstream.ok`. If false, instead of proxying the verbatim body, the worker now safely injects a generic `{"ok": false, "error": "upstream_error"}` JSON response. Kept upstream HTTP status correctly passed through.

### ✅ Verification
Tested with `vitest` in `cloudflare-worker/`.

### 📋 Notes
N/A

---
*PR created automatically by Jules for task [15447158946757009461](https://jules.google.com/task/15447158946757009461) started by @adhamhaithameid*