### PR TITLE
Ember: respect prefers-reduced-motion for pulse effect

### DIFF
--- a/extension/entrypoints/content/pulse-effect.ts
+++ b/extension/entrypoints/content/pulse-effect.ts
@@ -111,6 +111,11 @@ export function unmarkTargetElements(post: HTMLElement): void {
  * Includes debounce to prevent multiple clicks during animation.
  */
 export function triggerPulseEffect(post: HTMLElement, type: PulseType): void {
+  // Respect user's motion preference — WCAG 2.1 AA 2.3.3
+  if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    return; // Skip animation entirely for users who prefer no motion
+  }
+
   // animations in js instead of css?? sacrilege
   const ANIMATION_DURATION = 1500; // Match CSS animation duration
   const DEBOUNCE_ATTR = 'data-cqd-animating';


### PR DESCRIPTION
## 🔥 Ember — Extension UX Micro-Improvements
**Agent:** Ember | **Day:** Wednesday | **Date:** 2026-06-17

---

### 🔥 UX Finding
The pulse effect animation on the comment, edit, and combined badges ignored the user's system-level `prefers-reduced-motion` media query setting. This meant users with vestibular disorders were being subjected to unexpected motion.

### 👤 User Impact
Users who prefer reduced motion could experience discomfort or distraction from the sudden, repeated pulsing animations on the screen.

### 🔧 Improvement Applied
Added a check for `window.matchMedia('(prefers-reduced-motion: reduce)').matches` at the very beginning of the `triggerPulseEffect` function in `extension/entrypoints/content/pulse-effect.ts`. If this evaluates to true, the function returns early, completely bypassing the animation logic.

### ✅ Verification
Ran the extension test suites:
\`cd extension && pnpm run compile && pnpm run test && pnpm run build\`
All checks passed. Test suites confirm pulse effect and mark targets logic function as intended.

### 📋 Notes
This sets a solid precedent for ensuring any future JavaScript-based UI animations in the extension similarly respect user accessibility preferences for reduced motion.

---
*PR created automatically by Jules for task [16797394255381506315](https://jules.google.com/task/16797394255381506315) started by @adhamhaithameid*