### PR TITLE
Sage: suggest per-file-type filter and popup download history

### DIFF
--- a/.jules/sage.md
+++ b/.jules/sage.md
@@ -1,0 +1,12 @@
+## 2026-06-18 — Per-file-type filter and Download history
+**Issues Filed:**
+- Sage: add per-file-type filter to download-all — let teachers download only PDFs
+- Sage: show download history in popup — last 5 files downloaded this session
+
+**Rationale:**
+- **Per-file-type filter**: Addresses a significant user pain point in batch operations where users waste time managing unwanted file formats locally. The extension should provide more control over what gets downloaded rather than a pure "all or nothing" approach.
+- **Download history in popup**: This is a quick win. The background script already tracks `recentDownloads`, but this data is not surfaced to the user. Showing this history in the popup provides immediate, in-context feedback, reducing the need for users to verify downloads via the OS file explorer.
+
+**Areas for Next Run:**
+- Keyboard shortcuts for initiating downloads.
+- Improved handling/visibility of failed downloads within the "Download All" flow (e.g. pause/resume or retry failed).

--- a/sage-issue-1.md
+++ b/sage-issue-1.md
@@ -1,0 +1,38 @@
+---
+title: "Sage: add per-file-type filter to download-all — let teachers download only PDFs"
+---
+## 🌿 Sage — Extension Feature Suggestion
+**Agent:** Sage | **Day:** Thursday | **Date:** 2026-06-18
+
+---
+
+### 👤 User Story
+As a teacher, I want to filter the "Download All" action by file type, so that I can download only the final submission formats (like PDFs) instead of downloading every draft, image, or instruction document attached to the assignment.
+
+### 🔍 Problem Statement
+Currently, the "Download All" button grabs every detected file in the target group. When an assignment has 30 student submissions, and each student has attached 2 rough drafts (Docs) and 1 final submission (PDF), "Download All" pulls down 90 files. Teachers must then manually sort through their local folders to delete the 60 files they don't want to grade. The extension does not currently offer a way to selectively batch-download by extension type.
+
+### 💡 Proposed Solution
+Introduce a lightweight filter dropdown or toggle attached to the "Download All" button.
+- What the user sees: Hovering over or clicking a small gear/filter icon next to "Download All" reveals a quick checklist of detected file types in that group (e.g., `[x] PDF (30)  [x] DOCX (60)`).
+- How it integrates: The popup would be a small floating UI near the button. Unchecking a file type dynamically updates the "Download All" count.
+- Expected behavior: When "Download All" is clicked, only files matching the selected types are added to the download queue.
+
+### 🎯 Why Now
+Users are requesting ways to manage large volumes of files without cluttering their local storage. The extension's core promise is reducing repetitive clicks; currently, the user saves clicks downloading, but spends them deleting unwanted files later. This addresses a major friction point in the batch download workflow.
+
+### 📐 Acceptance Criteria
+- [ ] The filter UI only displays file extensions that are actually present in the current target group.
+- [ ] Deselecting a file type dynamically updates the counter on the "Download All" button.
+- [ ] Clicking "Download All" only initiates downloads for the currently selected file types.
+- [ ] Edge case handled: If all file types are deselected, the "Download All" button should be disabled.
+- [ ] Accessibility: The filter menu must be keyboard navigable and its state must be announced to screen readers.
+
+### 🔧 Technical Context
+This would require modifications to `extension/src/download-all/group-manager.ts` and `extension/src/download-all/state.ts` to track and expose the file types present in a `GroupState`. The UI rendering logic in the content script would need to attach the filter menu to the button. The `getCanonicalFileKey` or the `FileEntry` type might need an explicit `.ext` field to make grouping by type easier.
+
+### 📊 Estimated Complexity
+Medium (3-5 days) — The underlying state (`GroupState`) needs to group files by type, and we need to inject a new, accessible UI component next to the native DOM buttons without breaking the existing CSS layout.
+
+### 🔗 Related
+None.

--- a/sage-issue-2.md
+++ b/sage-issue-2.md
@@ -1,0 +1,38 @@
+---
+title: "Sage: show download history in popup — last 5 files downloaded this session"
+---
+## 🌿 Sage — Extension Feature Suggestion
+**Agent:** Sage | **Day:** Thursday | **Date:** 2026-06-18
+
+---
+
+### 👤 User Story
+As a student or teacher, I want to see a list of my recently downloaded files directly in the extension popup, so that I can verify what I just downloaded without having to open my operating system's file explorer or the browser's native download page.
+
+### 🔍 Problem Statement
+Currently, the extension popup offers settings and links, but no feedback on the user's active session. When a user downloads a batch of files (or even a single file), there is no easy way to confirm what was successfully saved other than navigating away from the Classroom context to check their local disk. This is especially problematic if a download fails silently or if the user forgets whether they already clicked a button.
+
+### 💡 Proposed Solution
+Add a "Recent Downloads" section to the extension popup (`extension/entrypoints/popup/App.tsx`).
+- What the user sees: A small list at the top or bottom of the popup displaying the names of the last 5 downloaded files, along with a timestamp (e.g., "Math_Homework.pdf - 2 mins ago").
+- How it integrates: The list would pull from the `recentDownloads` Map already maintained in the background service worker.
+- Expected behavior: The list updates dynamically as new files are downloaded during the session.
+
+### 🎯 Why Now
+The background worker already tracks `recentDownloads` (`recentDownloads.set(pending.fileMeta.name, Date.now())`), but this data is currently invisible to the user. Exposing it in the popup is a low-effort, high-impact way to build trust and provide immediate feedback on the extension's actions, addressing a common usability gap in batch operations.
+
+### 📐 Acceptance Criteria
+- [ ] The popup displays a list of up to 5 of the most recently downloaded files.
+- [ ] The list shows the filename and a relative timestamp (e.g., "Just now", "5m ago").
+- [ ] The list fetches its initial state from the background script upon opening the popup.
+- [ ] Edge case handled: If no files have been downloaded this session, display a friendly empty state (e.g., "No recent downloads in this session").
+- [ ] Accessibility: The list is readable by screen readers and logically ordered.
+
+### 🔧 Technical Context
+The data already exists in `extension/entrypoints/background/index.ts` within the `recentDownloads` map. The implementation requires setting up a message passing bridge (`chrome.runtime.sendMessage`) from the popup (`extension/entrypoints/popup/App.tsx`) to request the recent downloads list when the popup opens.
+
+### 📊 Estimated Complexity
+Small (1-2 days) — The tracking logic is already present in the background script. This task primarily involves creating a new UI component in the popup and wiring up the existing data via standard message passing.
+
+### 🔗 Related
+None.


### PR DESCRIPTION
This PR introduces two new feature suggestion issues from the Sage persona.

1. **Per-file-type filter for "Download All"**: Proposes adding a filter to the batch download UI so users can selectively download specific extensions (like PDFs), saving them from manually deleting unwanted files locally.
2. **Download history in popup**: Proposes surfacing the existing `recentDownloads` background state in the extension popup to provide immediate feedback on successful batch operations.

Both issues adhere to the strict Sage template, including YAML frontmatter and technical context. The run activity was also logged to `.jules/sage.md`.

---
*PR created automatically by Jules for task [5259793883514707393](https://jules.google.com/task/5259793883514707393) started by @adhamhaithameid*