### PR TITLE
Horizon: [Architecture Suggestions] Type Contracts & Dependency Management

### DIFF
--- a/.jules/horizon.md
+++ b/.jules/horizon.md
@@ -1,0 +1,10 @@
+## 2026-06-18 — Type Contracts & Dependency Management
+**Issues Filed:**
+- Horizon: no shared type contract between extension, worker, and website — schema drift risk
+- Horizon: Dependabot and Renovate conflict with partial workspace coverage — dependency management gap
+**Rationale:**
+- **Type Contracts:** The `OracleBatch` and related analytics payloads are duplicated across `extension/entrypoints/utils/analytics/types.ts` and `cloudflare-worker/src/types.ts`. This poses a significant schema drift risk where changes in one workspace could silently break cross-boundary communication. Creating a `packages/shared-types` workspace ensures the TypeScript compiler catches these mismatches.
+- **Dependency Management:** The repository currently runs both Dependabot and Renovate. Dependabot is misconfigured using `npm` instead of `pnpm`, completely omits the `website` workspace, and updates workspaces independently. Standardizing on Renovate and utilizing its monorepo grouping capabilities resolves these conflicts and ensures coordinated updates.
+**Areas for Next Run:**
+- E2E tests in `playwright.config.ts` currently only cover Chromium. Firefox should be added to the CI pipeline to catch cross-browser extension regressions.
+- Look into creating a full-stack local development script to simplify running the extension, worker, website, and backend simultaneously.

--- a/horizon-issue-1.md
+++ b/horizon-issue-1.md
@@ -1,0 +1,56 @@
+---
+title: "Horizon: no shared type contract between extension, worker, and website — schema drift risk"
+---
+
+## 🌅 Horizon — Architecture Suggestion
+**Agent:** Horizon | **Day:** Thursday | **Date:** 2026-06-18
+
+---
+
+### 🏗️ Architecture Area
+Type Contract
+
+### 🔍 Current State
+Currently, type contracts for the system's analytics and data models are duplicated across multiple workspaces. For instance, the `OracleBatch` and various event payloads are defined independently in:
+- `extension/entrypoints/utils/analytics/types.ts`
+- `cloudflare-worker/src/types.ts`
+- `oracle-backend/internal/model/counters.go` (backend equivalent)
+
+This duplication creates a severe risk of schema drift. If a property is added or renamed in the extension's analytics payload, it must be manually updated in the Cloudflare Worker and the Oracle backend, otherwise the system will experience silent data loss or API failures at the boundaries.
+
+### 💡 Proposed Improvement
+Create a new mono-repo workspace package specifically for shared type contracts (e.g., `packages/shared-types`).
+- Move all cross-boundary TypeScript definitions (like the analytics payload shapes and batch structures) into this shared package.
+- Both the `extension`, `cloudflare-worker`, and `website` workspaces should import these shared types using pnpm's workspace protocol (`workspace:*`).
+- Establish a single source of truth for the JSON schema/contract that the Oracle backend's Go structures (`internal/model/counters.go`) must align with, potentially using a shared JSON schema source that generates both TypeScript and Go structures.
+
+### 🎯 Why This Matters
+Type safety gaps at cross-boundary surfaces are the most common cause of silent system bugs in distributed applications. A shared type contract ensures that any change to the data schema will immediately fail the TypeScript compiler in all affected workspaces if not properly handled, turning runtime failures into build-time errors. It also improves developer velocity, as a developer working on a full-stack feature only needs to update the contract in one place.
+
+### 📐 Acceptance Criteria
+- [ ] A new `packages/shared-types` workspace is created with cross-boundary types.
+- [ ] `extension`, `cloudflare-worker`, and `website` use `workspace:*` to depend on the shared package.
+- [ ] Duplicated types in `extension/entrypoints/utils/analytics/types.ts` and `cloudflare-worker/src/types.ts` are removed and replaced with imports from the shared package.
+- [ ] The CI/CD pipeline correctly builds the shared package before dependent workspaces.
+- [ ] Documentation (`ARCHITECTURE.md`) is updated to describe the single source of truth for schemas.
+
+### 🔧 Technical Context
+- **Files to modify**:
+  - `extension/entrypoints/utils/analytics/types.ts`
+  - `cloudflare-worker/src/types.ts`
+  - `pnpm-workspace.yaml` (to add the new workspace)
+- **New files**:
+  - `packages/shared-types/package.json`
+  - `packages/shared-types/src/index.ts`
+
+### 📊 Estimated Complexity
+Medium (3–5 days). Extracting the types is straightforward, but ensuring the build process across the extension (WXT), worker (Wrangler), and website (SvelteKit) properly resolves the shared package requires careful `tsconfig.json` and build tool configuration.
+
+### ⚠️ Risks and Considerations
+- **Deployment Sequencing**: When the shared types change, the Oracle backend and Cloudflare Worker must be deployed before the extension or website to ensure they can parse the new payload format.
+- **Go Alignment**: The TypeScript types still need manual alignment with the Go models (`oracle-backend/internal/model/counters.go`) unless code generation from JSON Schema is implemented.
+
+### 🔗 Related
+- `extension/entrypoints/utils/analytics/types.ts`
+- `cloudflare-worker/src/types.ts`
+- `oracle-backend/internal/model/counters.go`

--- a/horizon-issue-2.md
+++ b/horizon-issue-2.md
@@ -1,0 +1,50 @@
+---
+title: "Horizon: Dependabot and Renovate conflict with partial workspace coverage — dependency management gap"
+---
+
+## 🌅 Horizon — Architecture Suggestion
+**Agent:** Horizon | **Day:** Thursday | **Date:** 2026-06-18
+
+---
+
+### 🏗️ Architecture Area
+Dependency Management
+
+### 🔍 Current State
+The repository currently uses both Dependabot (`.github/dependabot.yml`) and Renovate (`renovate.json`) concurrently, creating conflicting dependency management strategies.
+Furthermore, the Dependabot configuration has several significant issues:
+1. It is configured to use the `npm` package ecosystem for individual directories (`/extension`, `/cloudflare-worker`, `/oracle-backend`), completely ignoring the fact that this is a `pnpm` workspace with a root-level `pnpm-lock.yaml`.
+2. The `website` workspace is completely omitted from the Dependabot configuration.
+3. This setup leads to uncoordinated major dependency updates across workspaces (e.g., updating TypeScript in the worker but not the extension).
+
+### 💡 Proposed Improvement
+Standardize the entire mono-repo's dependency management on a single tool—specifically, Renovate.
+- Remove the `.github/dependabot.yml` configuration entirely.
+- Update `renovate.json` to properly understand the pnpm workspace structure and coordinate dependency updates globally across all workspaces.
+- Configure Renovate to group major version updates for shared dependencies (like `typescript` or `vite`) so that the `extension`, `cloudflare-worker`, and `website` upgrade in lockstep.
+
+### 🎯 Why This Matters
+Conflicting dependency managers lead to noisy PRs, lockfile conflicts, and potential CI failures when one tool overwrites the changes of another. Using `npm` Dependabot rules in a `pnpm` workspace breaks the workspace links and leads to incorrect `package.json` updates that bypass the root `pnpm-lock.yaml`. Additionally, omitting the `website` workspace leaves it vulnerable to outdated dependencies. Coordinated updates ensure that all workspaces build against the same core toolchain versions, reducing "works on my machine" bugs.
+
+### 📐 Acceptance Criteria
+- [ ] `.github/dependabot.yml` is deleted.
+- [ ] `renovate.json` is configured to recognize the pnpm workspace and the `website` directory.
+- [ ] Shared dependencies (e.g., TypeScript) are configured to group updates into a single PR spanning all workspaces.
+- [ ] CI pipeline continues to pass with the updated Renovate PRs.
+
+### 🔧 Technical Context
+- **Files to modify**:
+  - `renovate.json` (enhance configuration for grouping and pnpm)
+- **Files to delete**:
+  - `.github/dependabot.yml`
+
+### 📊 Estimated Complexity
+Small (1–2 days). Removing Dependabot is trivial. Updating Renovate configuration requires consulting the Renovate docs for monorepo and grouping settings, but is generally straightforward.
+
+### ⚠️ Risks and Considerations
+- Deleting Dependabot means relying entirely on Renovate for security alerts; ensure GitHub's native Dependabot alerts are still enabled at the repository settings level even if the auto-update PR action is removed.
+
+### 🔗 Related
+- `.github/dependabot.yml`
+- `renovate.json`
+- `pnpm-workspace.yaml`


### PR DESCRIPTION
Generated two GitHub Issues detailing architectural improvements for the mono-repo (shared types and standardizing on Renovate for dependencies), and updated the Horizon agent journal according to specifications.

---
*PR created automatically by Jules for task [3457198278181124821](https://jules.google.com/task/3457198278181124821) started by @adhamhaithameid*