### PR TITLE
🎨 Palette: Add input labels to toggle row switches for improved accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-18 - [Add input labels to toggle row switches]
+**Learning:** React toggles built with `div` and custom `onClick` logic often fail to provide native semantic keyboard accessibility, even if `onKeyDown` handlers are added manually. Replacing the text container `div` with a `<label>` element and linking it to the underlying checkbox using `htmlFor` restores native functionality where clicking the label natively triggers the `<input>`.
+**Action:** Prioritize using `<label>` with `htmlFor` over custom clickable `div` wrappers for inputs to ensure native keyboard navigability and semantic correctness.

--- a/extension/entrypoints/popup/App.tsx
+++ b/extension/entrypoints/popup/App.tsx
@@ -1568,6 +1568,7 @@ export function ToggleRow({
 }: ToggleRowProps) {
   const isDisabled = !!disabled || !!loading;
   const descriptionId = useId();
+  const inputId = useId();
 
   const handleChange = () => {
     if (!isDisabled) {
@@ -1589,9 +1590,9 @@ export function ToggleRow({
         primary ? 'cqd-toggle-row-primary' : ''
       } ${isDisabled ? 'disabled' : ''}`}
     >
-      <div
+      <label
         className="cqd-toggle-text"
-        onClick={handleChange}
+        htmlFor={inputId}
         style={{ cursor: isDisabled ? 'not-allowed' : 'pointer' }}
       >
         <div className="cqd-toggle-label">{label}</div>
@@ -1600,11 +1601,12 @@ export function ToggleRow({
             {description}
           </p>
         )}
-      </div>
+      </label>
       <label
         className={`cqd-switch ${loading ? 'cqd-switch-loading' : ''}`}
       >
         <input
+          id={inputId}
           type="checkbox"
           role="switch"
           aria-checked={checked}


### PR DESCRIPTION
💡 What: Replaced the clickable `div` wrapper for the toggle switch text with a semantic `<label>` element, linking it directly to the native checkbox input via `htmlFor`.
🎯 Why: To improve keyboard and screen reader accessibility by utilizing native HTML element behavior rather than relying solely on custom JavaScript `onClick` and `onKeyDown` handlers.
♿ Accessibility: Ensures that clicking anywhere on the text label correctly toggles the underlying checkbox input, improving standard keyboard navigability.

---
*PR created automatically by Jules for task [12998577760884063942](https://jules.google.com/task/12998577760884063942) started by @adhamhaithameid*