### PR TITLE
Vex: remove unused "accounts.google.com" from host_permissions

### DIFF
--- a/.jules/vex.md
+++ b/.jules/vex.md
@@ -1,0 +1,4 @@
+## 2024-05-18 — Removed "accounts.google.com" from host_permissions
+**Finding:** Found `https://accounts.google.com/*` in `host_permissions` in `wxt.config.ts`, but the extension did not use it or the `identity` permission.
+**Action:** Removed it from `host_permissions` in `extension/wxt.config.ts` to reduce attack surface and adhere to least privilege.
+**Learning:** `accounts.google.com` was previously present in the manifest likely as a leftover or speculative addition, but was completely unused by the source code since all authentication is handled via `chrome.identity.getAuthToken` which relies strictly on Manifest OAuth2 client configuration instead of manual requests.

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,6 +1,5 @@
 // filepath: extension/wxt.config.ts
 import { defineConfig } from 'wxt';
-
 const LOCAL_DEV_ORIGINS = ['http://localhost:3000', 'http://localhost:3001'];
 const LOCAL_DEV_SOCKETS = ['ws://localhost:3000', 'ws://localhost:3001'];
 const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -10,7 +9,6 @@ const devConnectSources = isDevelopment
 const devImageSources = isDevelopment
   ? ` ${LOCAL_DEV_ORIGINS.join(' ')}`
   : '';
-
 // the runner should be webExt
 export default defineConfig({
   webExt: {
@@ -41,7 +39,6 @@ export default defineConfig({
       'https://drive.google.com/*',
       'https://classroom.google.com/*',
       'https://drive.usercontent.google.com/*',
-      'https://accounts.google.com/*',
       'https://cqd-analytics.adhamhaithameid.workers.dev/*',
       'https://oracle.classroom-quick-downloader.com/*',
     ],


### PR DESCRIPTION
## 🔍 Vex — Manifest & Permissions Audit
**Agent:** Vex | **Date:** 2024-05-18

---

### 🚨 Severity
ENHANCEMENT

### 🔍 Finding
Found `https://accounts.google.com/*` in `host_permissions` in `extension/wxt.config.ts`, but the extension did not use it or the `identity` permission.

### 🎯 Impact
Overly broad permissions increase the attack surface and can lead to user distrust or strict review by the Chrome Web Store. Removing unused permissions adheres to the principle of least privilege.

### 🔧 Fix Applied
Removed `https://accounts.google.com/*` from the `host_permissions` array in `extension/wxt.config.ts`. Also added this finding to `.jules/vex.md`.

### ✅ Verification
Verified via `pnpm run compile`, `pnpm run build`, and `pnpm run test` in `extension/`, plus `pnpm run test:smoke` at the root level. All tests and builds pass.

### 📋 Notes
This reduces the permissions the extension asks for, making it safer.

---
*PR created automatically by Jules for task [11723812842446497652](https://jules.google.com/task/11723812842446497652) started by @adhamhaithameid*