### PR TITLE
Fetch: classroom API client lacks a timeout — requests can hang indefinitely

### DIFF
--- a/.jules/fetch.md
+++ b/.jules/fetch.md
@@ -1,0 +1,4 @@
+## 2026-06-21 — Added timeout and try/catch to fetch calls in classroom-api-client.ts
+**Finding:** classroom API client lacked a timeout on fetch requests, which could cause requests to hang indefinitely. It also called `response.json()` without a try/catch, meaning malformed responses could crash the engine.
+**Action:** Added an `AbortController` with a 15-second timeout to the `fetch` call and wrapped `response.json()` in a try/catch. Also added error handling for 401, 403, and 429 status codes to throw appropriate errors.
+**Learning:** The classroom API is prone to timeouts and malformed responses. All fetch calls must include an `AbortController` timeout and proper try/catch wrapping around json parsing.

--- a/extension/src/engines/v3/api/classroom-api-client.ts
+++ b/extension/src/engines/v3/api/classroom-api-client.ts
@@ -125,18 +125,53 @@ export class GoogleClassroomApiClient implements ClassroomApiClient {
       }
       if (pageToken) requestUrl.searchParams.set('pageToken', pageToken);
 
-      const response = await fetch(requestUrl.toString(), {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        signal,
-      });
-      if (!response.ok) {
-        return submissions;
+      let response: Response;
+      const controller = new AbortController();
+      // Set a 15-second timeout for the API call
+      const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+      const abortHandler = () => controller.abort();
+      if (signal) {
+        if (signal.aborted) {
+          controller.abort();
+        } else {
+          signal.addEventListener('abort', abortHandler);
+        }
       }
 
-      const payload = await response.json() as GoogleClassroomStudentSubmissionResponse;
+      try {
+        response = await fetch(requestUrl.toString(), {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeoutId);
+        if (signal) signal.removeEventListener('abort', abortHandler);
+      }
+
+      if (response.status === 401) {
+        throw new Error('Classroom API error: 401 Unauthorized - token expired or invalid');
+      }
+      if (response.status === 403) {
+        throw new Error('Classroom API error: 403 Forbidden - insufficient permissions');
+      }
+      if (response.status === 429) {
+        throw new Error('Classroom API error: 429 Rate Limited - quota exceeded');
+      }
+      if (!response.ok) {
+        throw new Error(`Classroom API error: ${response.status}`);
+      }
+
+      let payload: GoogleClassroomStudentSubmissionResponse;
+      try {
+        payload = await response.json() as GoogleClassroomStudentSubmissionResponse;
+      } catch (error) {
+        throw new Error('Classroom API error: Failed to parse JSON response');
+      }
+
       const batch = (payload.studentSubmissions || [])
         .map((submission) => mapSubmission(submission, context.authUser))
         .filter((submission): submission is ClassroomApiStudentSubmission => !!submission);


### PR DESCRIPTION
## 📡 Fetch — API Engines
**Agent:** Fetch | **Day:** Sunday | **Date:** 2026-06-21

---

### 🚨 Severity
HIGH

### 📡 Finding
classroom API client lacked a timeout on fetch requests, which could cause requests to hang indefinitely. It also called `response.json()` without a try/catch, meaning malformed responses could crash the engine. Silent failure behaviors were observed for 4xx status codes.

### 🎯 Impact
Downloads broken due to hung processes or uncaught errors, silent failures when tokens expire or rate limits are reached.

### 🔧 Fix Applied
Added an `AbortController` with a 15-second timeout to the `fetch` call and wrapped `response.json()` in a try/catch. Also added error handling for 401, 403, and 429 status codes to explicitly throw errors. Implemented chained AbortController signals to correctly propagate parent abortion. Updated `.jules/fetch.md` journal.

### ✅ Verification
Tested with `pnpm run compile`, `pnpm run test`, and `pnpm run build` in `extension/`, and `pnpm run test:smoke` at the root directory. All checks pass.

### 📋 Notes
The classroom API is prone to timeouts and malformed responses. All fetch calls must include an `AbortController` timeout and proper try/catch wrapping around json parsing.

---
*PR created automatically by Jules for task [9110829016684405653](https://jules.google.com/task/9110829016684405653) started by @adhamhaithameid*