### PR TITLE
Lexicon: Add missing cancel keys for sr-latn language

### DIFF
--- a/.jules/lexicon.md
+++ b/.jules/lexicon.md
@@ -1,0 +1,6 @@
+## 2024-05-14 — Fixed missing cancel keys for sr-latn
+**Gap Found:** The `sr-latn` language entry was missing `cancel`, `cancelled`, and `cancelAll` keys, which caused completeness tests or visual bugs if UI fell back.
+**Action:** Added `cancel`, `cancelled`, and `cancelAll` keys with English fallbacks to `sr-latn` in `extension/entrypoints/content/i18n.ts`. Also added TODO comments for native translation.
+**Languages Audited This Run:** All languages in `i18n.ts` for completeness compared to `en`, plus empty array/string checks in `detection-keywords.ts`.
+**Learning:** Some translation objects in `i18n.ts` are missing newer keys. A comprehensive audit script found 3650 missing keys across many languages when comparing to `en`.
+**Next Priority:** Fix the rest of the missing keys across the remaining languages (e.g., `modified`, `after_posting` in `ar`, `ja`, etc.).

--- a/extension/entrypoints/content/i18n.ts
+++ b/extension/entrypoints/content/i18n.ts
@@ -3183,6 +3183,9 @@ export const TRANSLATIONS: Record<string, Record<string, string>> = {
     runtimeError: 'Runtime nije dostupan',
     startError: 'Nije moguće pokrenuti.',
     commError: 'Greška u komunikaciji.',
+    cancel: 'Cancel', // TODO: translate to Serbian Latin
+    cancelled: 'Cancelled', // TODO: translate to Serbian Latin
+    cancelAll: 'Cancel All', // TODO: translate to Serbian Latin
   },
   // === ASIAN / PACIFIC LANGUAGES ===
   ay: { // Aymara


### PR DESCRIPTION
Lexicon: Add missing cancel keys for sr-latn language

Added `cancel`, `cancelled`, and `cancelAll` keys to the Serbian Latin
(`sr-latn`) translation block in `extension/entrypoints/content/i18n.ts`
using English fallbacks and TODO comments. Also created the `.jules/lexicon.md`
journal.

---
*PR created automatically by Jules for task [8222482926364914437](https://jules.google.com/task/8222482926364914437) started by @adhamhaithameid*