### PR TITLE
Aria: layout missing skip-to-main-content link and focus management — keyboard users cannot skip nav

### DIFF
--- a/.jules/aria.md
+++ b/.jules/aria.md
@@ -1,0 +1,4 @@
+## 2025-05-14 — Added skip link and focus management
+**Finding:** Layout `website/src/routes/+layout.svelte` was missing a skip navigation link and focus management on route transition — WCAG 2.4.1 Skip Navigation and WCAG 2.4.3 Focus Order failures
+**Action:** Added `<a href="#main-content" class="skip-nav">Skip to main content</a>` visibly available on focus. Added `<main id="main-content" tabindex="-1">`. Hooked `afterNavigate` to programmatically focus the `#main-content` after route transitions.
+**Learning:** SvelteKit client-side route transitions break normal document focus progression; we must explicitly provide `afterNavigate` handlers to bring screen reader focus to the target view container (`<main>`).

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import logo from '$lib/assets/cqd-logo.svg';
@@ -118,6 +119,15 @@
     mobileNavOpen = false;
   }
 
+  afterNavigate(() => {
+    if (typeof document !== 'undefined') {
+      const mainContent = document.querySelector('#main-content');
+      if (mainContent) {
+        (mainContent as HTMLElement).focus();
+      }
+    }
+  });
+
   onMount(() => {
     detectedBrowser = detectBrowserFromNavigator();
     hideChrome = new URLSearchParams(window.location.search).has('embed');
@@ -151,6 +161,7 @@
 <LoadingScreen />
 
 <div class="site-shell" class:o2-fullscreen={hideChrome}>
+  <a href="#main-content" class="skip-nav">Skip to main content</a>
   {#if !hideChrome}
   <header class="l2-nav-shell">
     <div class="l2-nav-inner l2-nav-fullwidth">
@@ -238,6 +249,8 @@
   {/if}
 
   <main
+    id="main-content"
+    tabindex="-1"
     class:site-main={!isOverviewStyleRoute && !hideChrome}
     class:site-main-overview-style={isOverviewStyleRoute && !hideChrome}
     class:l2-wrap={!isOverviewStyleRoute && !hideChrome}
@@ -279,9 +292,27 @@
 </div>
 
 <style>
+  .skip-nav {
+    position: absolute;
+    top: -100%;
+    left: 0;
+    padding: 0.5rem 1rem;
+    background: var(--gc-green);
+    color: white;
+    z-index: 999;
+    text-decoration: none;
+  }
+  .skip-nav:focus {
+    top: 0;
+  }
+
   main {
     flex: 1;
     min-height: 0;
+  }
+
+  #main-content:focus:not(:focus-visible) {
+    outline: none;
   }
 
   .site-shell {


### PR DESCRIPTION
## ♿ Aria — Website Accessibility
**Agent:** Aria | **Day:** Wednesday

---

### ♿ WCAG Violation
WCAG 2.1 AA — 2.4.1 Skip Navigation and WCAG 2.1 AA — 2.4.3 Focus Order

### 🔍 Finding
`website/src/routes/+layout.svelte` lacked a skip navigation link, forcing keyboard users to tab through the navigation on every page load. Furthermore, because SvelteKit handles client-side routing, screen reader users were losing their place/focus after route transitions. 

### 👤 User Impact
Keyboard-only users were forced to spend a lot of time bypassing the primary navigation on every new page interaction. Screen reader users would become disoriented when the client-side router loaded new page data but did not manage focus properly.

### 🔧 Fix Applied
- Added `<a href="#main-content" class="skip-nav">Skip to main content</a>` visibly available upon keyboard focus.
- Modified the primary content container `<main>` to have `id="main-content"` and `tabindex="-1"`.
- Wired an `afterNavigate` Svelte hook to programmatically focus the `#main-content` target on client-side route transitions, maintaining focus context for SR users.
- Substituted `outline: none;` on `#main-content` with `:focus:not(:focus-visible) { outline: none; }` to maintain the highest level of adherence with accessibility rules while achieving optimal UX.

### ✅ Verification
- Type checked via `pnpm run check` and verified successfully.
- Tests validated via `pnpm run test` and integration/smoke tests successfully executed.
- Verified skip-nav visually shows on element focus.

### 📋 Notes
In SvelteKit SPA's, explicit `afterNavigate` handling is often necessary to recreate normal browser accessibility behaviors for programmatic DOM transitions.

---
*PR created automatically by Jules for task [15913759943216630708](https://jules.google.com/task/15913759943216630708) started by @adhamhaithameid*