### PR TITLE
Ember: add missing aria-labels to Download All button states

### DIFF
--- a/extension/src/v2/render/download-all-renderer.ts
+++ b/extension/src/v2/render/download-all-renderer.ts
@@ -151,6 +151,7 @@ export function updateDownloadAllUI(
       button.disabled = false;
       if (label) label.textContent = 'Download All';
       if (countEl) countEl.textContent = String(progress.total);
+      button.setAttribute('aria-label', `Download all ${progress.total} files`);
       break;
 
     case 'downloading':
@@ -158,6 +159,7 @@ export function updateDownloadAllUI(
       button.classList.add('cqd-loading');
       if (label) label.textContent = `Downloading`;
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
+      button.setAttribute('aria-label', `Downloading files: ${progress.completed} of ${progress.total} complete`);
       break;
 
     case 'success':
@@ -165,6 +167,7 @@ export function updateDownloadAllUI(
       button.classList.add('cqd-success');
       if (label) label.textContent = 'Downloaded';
       if (countEl) countEl.textContent = `${progress.total}`;
+      button.setAttribute('aria-label', `Successfully downloaded all ${progress.total} files`);
       break;
 
     case 'error':
@@ -172,6 +175,7 @@ export function updateDownloadAllUI(
       button.classList.add('cqd-error');
       if (label) label.textContent = 'Failed';
       if (countEl) countEl.textContent = `${progress.failed}`;
+      button.setAttribute('aria-label', `Failed to download ${progress.failed} files`);
       break;
 
     case 'partial':
@@ -179,6 +183,7 @@ export function updateDownloadAllUI(
       button.classList.add('cqd-error');
       if (label) label.textContent = 'Partial';
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
+      button.setAttribute('aria-label', `Partially downloaded: ${progress.completed} successful, ${progress.failed} failed of ${progress.total} files`);
       break;
 
     case 'cancelled':
@@ -186,6 +191,7 @@ export function updateDownloadAllUI(
       button.classList.add('cqd-cancelled');
       if (label) label.textContent = 'Cancelled';
       if (countEl) countEl.textContent = `${progress.completed}/${progress.total}`;
+      button.setAttribute('aria-label', `Download cancelled. ${progress.completed} of ${progress.total} files downloaded`);
       break;
   }
 }

--- a/extension/tests/v2-download-all-renderer.test.ts
+++ b/extension/tests/v2-download-all-renderer.test.ts
@@ -137,6 +137,16 @@ describe('Download All Renderer: UI Updates', () => {
     document.body.innerHTML = '';
   });
 
+  it('updateDownloadAllUI sets idle state correctly', () => {
+    const btn = mockDownloadAllButton();
+    document.body.appendChild(btn);
+
+    const progress = createProgress(3);
+    updateDownloadAllUI(btn, progress);
+
+    expect(btn.getAttribute('aria-label')).toBe('Download all 3 files');
+  });
+
   it('updateDownloadAllUI sets loading state', () => {
     const btn = mockDownloadAllButton();
     document.body.appendChild(btn);
@@ -152,6 +162,7 @@ describe('Download All Renderer: UI Updates', () => {
     expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Downloading');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('1/3');
+    expect(btn.getAttribute('aria-label')).toBe('Downloading files: 1 of 3 complete');
   });
 
   it('updateDownloadAllUI sets success state', () => {
@@ -167,6 +178,7 @@ describe('Download All Renderer: UI Updates', () => {
     expect(btn.classList.contains('cqd-success')).toBe(true);
     expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Downloaded');
+    expect(btn.getAttribute('aria-label')).toBe('Successfully downloaded all 3 files');
   });
 
   it('updateDownloadAllUI sets error state', () => {
@@ -183,6 +195,7 @@ describe('Download All Renderer: UI Updates', () => {
     expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Failed');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('3');
+    expect(btn.getAttribute('aria-label')).toBe('Failed to download 3 files');
   });
 
   it('updateDownloadAllUI sets partial state', () => {
@@ -200,6 +213,7 @@ describe('Download All Renderer: UI Updates', () => {
     expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Partial');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('2/3');
+    expect(btn.getAttribute('aria-label')).toBe('Partially downloaded: 2 successful, 1 failed of 3 files');
   });
 
   it('updateDownloadAllUI sets cancelled state', () => {
@@ -216,6 +230,7 @@ describe('Download All Renderer: UI Updates', () => {
     expect(btn.disabled).toBe(true);
     expect(btn.querySelector('.cqd-v2-label')!.textContent).toBe('Cancelled');
     expect(btn.querySelector('.cqd-v2-count')!.textContent).toBe('1/3');
+    expect(btn.getAttribute('aria-label')).toBe('Download cancelled. 1 of 3 files downloaded');
   });
 
   it('updateDownloadAllUI clears previous state classes', () => {


### PR DESCRIPTION
## 🔥 Ember — Extension UX Micro-Improvements
**Agent:** Ember | **Day:** Wednesday | **Date:** 2024-11-20

---

### 🔥 UX Finding
The "Download All" button lacked `aria-label` attributes reflecting its different states (e.g. idle, downloading, success, error, partial, cancelled), which made it difficult for screen reader users to understand its current progress status.

### 👤 User Impact
Users relying on screen readers wouldn't receive verbal confirmation of what state the Download All button is currently in (whether a batch is actively downloading, has succeeded, failed, or was cancelled). It only reads as the visible text, which in some states might not be descriptive enough of partial progress or active downloading.

### 🔧 Improvement Applied
Added context-rich `aria-label`s directly to the button element during the `updateDownloadAllUI` updates so that state changes are explicitly accessible to assistive technologies. Added associated tests in `v2-download-all-renderer.test.ts`.

### ✅ Verification
Tested the various progress states programmatically. Run `cd extension && pnpm run test content-download-all-renderer` (or equivalent test runner pattern, here `v2-download-all-renderer.test.ts`) to see the tests pass. Build completed successfully. Monorepo smoke tests passed.

### 📋 Notes
Screen reader users need explicit `aria-label` updates on elements that change state dynamically without triggering full DOM re-renders or focus changes. This pattern should be consistently applied across dynamically-updated UI components.

---
*PR created automatically by Jules for task [3364824515258200236](https://jules.google.com/task/3364824515258200236) started by @adhamhaithameid*