### PR TITLE
Signal: add noindex to internal preview routes

### DIFF
--- a/.jules/signal.md
+++ b/.jules/signal.md
@@ -1,0 +1,5 @@
+
+## 2025-02-12 — Added noindex to internal draft routes
+**Finding:** The internal preview routes `/emails` and `/emails2` were accessible to crawlers and missing `noindex` directives, creating a risk of search engines indexing these draft pages.
+**Action:** Added `noindex={true}` to the `<SeoMeta>` component in `website/src/routes/emails/+page.svelte` and `website/src/routes/emails2/+page.svelte`. Also added `Disallow: /emails` and `Disallow: /emails2` to `website/src/routes/robots.txt/+server.ts`.
+**Learning:** For SvelteKit sites, utility/preview pages should explicitly declare `noindex={true}` via `<SeoMeta>` and be blocked via robots.txt to ensure they do not pollute search indexes.

--- a/website/src/routes/emails/+page.svelte
+++ b/website/src/routes/emails/+page.svelte
@@ -12,6 +12,7 @@
   description="Browser preview of the Classroom Quick Downloader advertisement email."
   path="/emails"
   keywords="classroom quick downloader email, classroom extension email ad"
+  noindex={true}
 />
 
 <section class="emails-page">

--- a/website/src/routes/emails2/+page.svelte
+++ b/website/src/routes/emails2/+page.svelte
@@ -75,6 +75,7 @@
   description="Svelte-native email preview for Classroom Quick Downloader with consistent cross-device rendering."
   path="/emails2"
   keywords="classroom quick downloader email preview, svelte email page"
+  noindex={true}
 />
 
 <section class="emails2-page" aria-label="Classroom Quick Downloader email preview">

--- a/website/src/routes/robots.txt/+server.ts
+++ b/website/src/routes/robots.txt/+server.ts
@@ -16,6 +16,8 @@ Disallow: /uninstall
 Disallow: /404
 Disallow: /overview-editor
 Disallow: /landing2
+Disallow: /emails
+Disallow: /emails2
 
 Sitemap: ${siteUrl}/sitemap.xml
 ${host ? `Host: ${host}\n` : ''}


### PR DESCRIPTION
## 📶 Signal — Website SEO
**Agent:** Signal | **Day:** Wednesday | **Date:** 2025-02-12

---

### 📶 SEO Finding
The internal email preview routes `/emails` and `/emails2` were accessible to crawlers and lacked explicit `noindex` directives or blockages in `robots.txt`, creating a risk of search engines crawling and indexing these draft/preview pages.

### 🎯 Search Impact
These pages are utility previews with no unique user-facing content. Having them indexed could pollute search results and create duplicate or low-quality content warnings in Google Search Console. Blocking them ensures search engines only spend crawl budget on actual user-facing pages.

### 🔧 Fix Applied
- Added `noindex={true}` to the `<SeoMeta>` component in `website/src/routes/emails/+page.svelte`.
- Added `noindex={true}` to the `<SeoMeta>` component in `website/src/routes/emails2/+page.svelte`.
- Added `Disallow: /emails` and `Disallow: /emails2` to `website/src/routes/robots.txt/+server.ts`.

### ✅ Verification
- Ran `pnpm check` and `pnpm test` successfully.
- Ran `pnpm build` and verified the generated `emails2.html` file includes `<meta name="robots" content="noindex, nofollow"/>` and `emails.html` properly redirects.
- Ran `pnpm run test:smoke` successfully across all monorepo packages.

### 📋 Notes
Any future utility or internal-only preview pages added to the website should follow this exact pattern of explicit `<SeoMeta noindex={true} />` and a corresponding `Disallow` rule in `robots.txt`.

---
*PR created automatically by Jules for task [17895795148081223345](https://jules.google.com/task/17895795148081223345) started by @adhamhaithameid*