### PR TITLE
Oracle: [Backend Suggestions] Database Migrations Tracking & Deep Health Check

### DIFF
--- a/.jules/oracle.md
+++ b/.jules/oracle.md
@@ -1,0 +1,8 @@
+## 2026-06-25 — Database migrations tracking and deep health check endpoints
+**Issues Filed:**
+- Oracle: add database migration version tracking to db schemas
+- Oracle: add /health/deep endpoint that validates Postgres DB connectivity and query execution
+**Rationale:** In a single-maintainer system, survivability relies on explicit visibility. Migrations currently use implicit `IF NOT EXISTS` creation, making schema management and tracking brittle over time. A deep health check provides early alerts to data store failures before user-visible symptoms occur, rather than relying on a false-positive API ping.
+**Areas for Next Run:**
+- Idempotency key tracking in `store_batch.go` to prevent duplication (though there are some naive UNIQUE constraints).
+- Pagination on `pipeline.go` handlers to prevent unbounded result sets.

--- a/oracle-db-migration.md
+++ b/oracle-db-migration.md
@@ -1,0 +1,47 @@
+---
+title: "Oracle: add database migration version tracking to db schemas"
+---
+
+## 🔮 Oracle — Backend Suggestion
+**Agent:** Oracle | **Day:** Thursday | **Date:** 2026-06-25
+
+---
+
+### 🔧 Improvement Type
+Data Model / Operational
+
+### 🔍 Current State
+Currently, both the SQLite and PostgreSQL databases do not track schema migration versions.
+- In `oracle-backend/internal/db/db.go`, `Migrate()` executes a hardcoded list of `CREATE TABLE IF NOT EXISTS` statements.
+- In `oracle-backend/internal/db/postgres.go`, `migratePostgres()` executes a hardcoded list of `CREATE TABLE IF NOT EXISTS` statements.
+There is no `schema_migrations` table to track which migrations have been applied. The application blindly relies on `IF NOT EXISTS` constructs to avoid errors, which makes schema alterations (like adding a column, modifying indexes, or dropping tables) incredibly risky and difficult to manage across different environments, especially in a single-maintainer setup where memory of recent changes fades quickly.
+
+### 💡 Proposed Improvement
+Introduce a formal schema migration tracking table and mechanism:
+- Add a `schema_migrations` table with a `version` (integer or timestamp) and `applied_at` column to both SQLite and Postgres initialization scripts.
+- Refactor the migration logic in `db.go` and `postgres.go` to iterate over an ordered list or embedded directory of migration files (or structs), checking the `schema_migrations` table before applying each one.
+- Update the application startup sequence to log the current database version.
+
+### 🎯 Why This Matters
+In a single-maintainer context where the service is checked on roughly monthly, knowing exactly what schema is running in production is critical. Without version tracking, the maintainer cannot reliably answer "Did this schema change get deployed?" without manually querying the database for the existence of specific columns. Furthermore, relying on `IF NOT EXISTS` completely falls apart when a column needs to be renamed or an index needs to be dropped. Migration version tracking provides a clear, reliable history of database state and prevents deployment mysteries.
+
+### 📐 Acceptance Criteria
+- [ ] A `schema_migrations` table is automatically created on startup if it doesn't exist.
+- [ ] Each applied migration inserts its version into `schema_migrations`.
+- [ ] Startup logs output the current database schema version.
+- [ ] Subsequent restarts do not attempt to reapply already-applied migrations.
+- [ ] All existing `CREATE TABLE` and `CREATE INDEX` statements are moved into the new versioned migration framework (as version 1).
+
+### 🔧 Technical Context
+- Modifies `oracle-backend/internal/db/db.go` to implement migration tracking for SQLite.
+- Modifies `oracle-backend/internal/db/postgres.go` to implement migration tracking for PostgreSQL.
+- Potentially creates a new package `oracle-backend/internal/db/migrations` or uses existing Go packages like `golang-migrate/migrate` or `pressly/goose` to handle the logic.
+
+### 📊 Estimated Complexity
+Medium (3–5 days) — Requires carefully converting the existing implicit schema into an explicit "Version 1" migration and ensuring that existing databases gracefully adopt the new migration table without attempting to recreate existing tables.
+
+### ⚠️ Risks and Considerations
+- **Adoption on existing databases:** The system must gracefully handle the case where tables already exist but the `schema_migrations` table does not. It should probably create the migration table and mark "Version 1" as already applied if a known base table (e.g., `batches` or `pg_ingest_batches`) exists.
+
+### 🔗 Related
+None.

--- a/oracle-deep-health-check.md
+++ b/oracle-deep-health-check.md
@@ -1,0 +1,48 @@
+---
+title: "Oracle: add /health/deep endpoint that validates Postgres DB connectivity and query execution"
+---
+
+## 🔮 Oracle — Backend Suggestion
+**Agent:** Oracle | **Day:** Thursday | **Date:** 2026-06-25
+
+---
+
+### 🔧 Improvement Type
+API Enhancement / Observability
+
+### 🔍 Current State
+The backend provides health endpoints like `/health` (which just returns static JSON) and `/health/db` (which executes a lightweight `SELECT 1` on the SQLite database). However, it lacks a comprehensive, deep health check that validates connectivity and query execution for the PostgreSQL database (`postgresDB`), which handles critical paths like the ingest outbox and raw event storage.
+- `oracle-backend/internal/handlers/health.go` defines `DBHealthHandler` but it only accepts and tests a `*sql.DB` (specifically the SQLite DB in `main.go`).
+- The `ReadyHandler` in `health.go` checks if migrations are done and optionally pings Postgres if configured, but a dedicated deep health check endpoint for ongoing load-balancer or uptime monitoring that thoroughly verifies both SQLite and Postgres read/write capability is missing.
+
+### 💡 Proposed Improvement
+Add a new `/health/deep` endpoint that performs a comprehensive check of all critical backend dependencies:
+- Verifies SQLite connectivity and query execution.
+- Verifies PostgreSQL connectivity and query execution (if configured).
+- Checks storage watermarks/disk space availability (using the existing `StorageGuard`).
+- Returns a structured JSON response indicating the individual health status of each component and an overall `ok` boolean.
+
+### 🎯 Why This Matters
+For a single-maintainer service, relying on a simple HTTP `200 OK` or a localized SQLite ping gives a false sense of security. If the PostgreSQL database goes down or becomes unreachable, the main `/health` check will still pass, but critical background jobs (like the `SQLiteToPostgresRelay`) and ingest endpoints will silently fail or back up. A deep health check allows an external monitor (like Uptime Kuma) to catch DB outages or disk space exhaustion before users report missing analytics data, enabling faster response times and preventing data loss.
+
+### 📐 Acceptance Criteria
+- [ ] A new `DeepHealthHandler` is added to `oracle-backend/internal/handlers/health.go`.
+- [ ] The handler pings both SQLite and PostgreSQL databases (if Postgres is configured).
+- [ ] The handler incorporates a check on the `StorageGuard` to ensure disk space is within acceptable limits.
+- [ ] The response is a JSON object detailing the status of `sqlite`, `postgres`, and `storage`, along with an overall status.
+- [ ] The handler returns HTTP 200 if all configured dependencies are healthy, and HTTP 503 Service Unavailable if any critical component is failing.
+- [ ] The endpoint `/health/deep` is registered in `oracle-backend/cmd/app/main.go`.
+
+### 🔧 Technical Context
+- Modifies `oracle-backend/internal/handlers/health.go` to add `DeepHealthHandler`.
+- Modifies `oracle-backend/cmd/app/main.go` to inject dependencies (SQLite `db`, Postgres `db`, and `storageGuard`) and route `/health/deep` to the new handler.
+
+### 📊 Estimated Complexity
+Small (1–2 days) — The underlying ping and status mechanisms already exist; it mostly requires assembling them into a unified, structured endpoint and configuring the route.
+
+### ⚠️ Risks and Considerations
+- **Load balancing:** Deep health checks should not be executed too frequently (e.g., every second by a load balancer) to avoid unnecessary database load. Monitoring tools should be configured to poll this endpoint at a reasonable interval (e.g., every 30-60 seconds).
+- **Postgres optionality:** The handler must gracefully handle environments where PostgreSQL is not configured (e.g., local development), skipping the Postgres check and returning healthy for that component.
+
+### 🔗 Related
+None.


### PR DESCRIPTION
Filed two issues as per Oracle's mandate, focusing on database migration tracking and a deep DB health check endpoint, both addressing operational observability and maintainability. Updated `.jules/oracle.md` journal accordingly.

---
*PR created automatically by Jules for task [6742947901409363615](https://jules.google.com/task/6742947901409363615) started by @adhamhaithameid*