### PR TITLE
Reach: submit existing promo tiles to Chrome Web Store

### DIFF
--- a/.jules/reach.md
+++ b/.jules/reach.md
@@ -1,0 +1,5 @@
+## 2026-06-25 — Submit existing promo tiles to Chrome Web Store
+**Issue Filed:** Reach: submit existing promo tiles to Chrome Web Store
+**Channel:** Chrome Web Store
+**Rationale:** The extension currently has existing promo tiles in `docs/Design/Advertisement/` but they are likely not uploaded, making the listing look less professional and ineligible for featuring on the Chrome Web Store category pages. This is a 5-minute task utilizing existing assets to increase conversions and eligibility.
+**Next Priority:** Check if there are screenshots missing from Firefox or Edge listings, or identify the best first target for a genuine community presence (like r/GoogleClassroom).

--- a/Reach-Submit-Promo-Tiles.md
+++ b/Reach-Submit-Promo-Tiles.md
@@ -1,0 +1,43 @@
+---
+title: "Reach: submit existing promo tiles to Chrome Web Store"
+---
+## 🚀 Reach — Growth & Distribution
+**Agent:** Reach | **Day:** Thursday | **Date:** 2026-06-25
+**Channel:** Chrome Web Store
+**Cost:** Free
+
+---
+
+### 🎯 Growth Opportunity
+The Classroom Quick Downloader Chrome Web Store listing currently lacks promotional tiles. We already have these assets created and stored in `docs/Design/Advertisement/` (`Marquee promo tile.png` and `Small promo tile.png`). Uploading these to the Developer Dashboard makes the extension eligible for featuring and significantly improves the professional appearance of the listing.
+
+### 📊 Why This Matters
+The Chrome Web Store algorithm heavily favors extensions with complete listings for featuring and search ranking. The Marquee tile (1400x560px) is required for the extension to be featured on category pages, and the Small promo tile (440x280px) is used in search results and related extensions widgets. A student or teacher searching for "Google Classroom download" is much more likely to click on a listing that has a high-quality promo tile than one with just a generic icon. Since the assets already exist, this is a 5-minute task with high potential return.
+
+### 💡 Specific Recommendation
+1. Retrieve the existing promo tile files from the repository:
+   - `docs/Design/Advertisement/Marquee promo tile.png` (1400x560)
+   - `docs/Design/Advertisement/Small promo tile.png` (440x280)
+2. Open the Chrome Developer Dashboard, navigate to the Classroom Quick Downloader listing > Store Listing tab.
+3. Under the "Graphic assets" section, upload the Marquee promo tile to the "Marquee promo tile" slot and the Small promo tile to the "Small promo tile" slot.
+4. Save and submit the listing for review.
+
+### 📐 Acceptance Criteria
+- [ ] The Small promo tile (`docs/Design/Advertisement/Small promo tile.png`) is uploaded to the Chrome Web Store listing.
+- [ ] The Marquee promo tile (`docs/Design/Advertisement/Marquee promo tile.png`) is uploaded to the Chrome Web Store listing.
+- [ ] The Chrome Web Store listing is submitted for review to apply the changes.
+
+### 🔧 How to Implement
+1. Log into the [Chrome Developer Dashboard](https://chrome.google.com/webstore/developer/dashboard).
+2. Click on the "Classroom Quick Downloader" item.
+3. Click on the "Store listing" tab in the left sidebar.
+4. Scroll down to the "Graphic assets" section.
+5. In the "Small promo tile (440 x 280)" box, upload `docs/Design/Advertisement/Small promo tile.png`.
+6. In the "Marquee promo tile (1400 x 560)" box, upload `docs/Design/Advertisement/Marquee promo tile.png`.
+7. Click "Save draft" at the top right, then "Submit for review".
+
+### 📊 Estimated Impact
+**High.** Required for featuring on the Chrome Web Store. Improves click-through rates from search results and related extension suggestions by providing a larger, more visually appealing hit target. It utilizes existing assets, making it a zero-effort, high-reward change.
+
+### 🔗 Related
+None.


### PR DESCRIPTION
Creates an issue outlining the growth opportunity of uploading the existing Marquee and Small promo tiles to the Chrome Web Store to improve visibility and eligibility for featuring.

---
*PR created automatically by Jules for task [15488979419961680888](https://jules.google.com/task/15488979419961680888) started by @adhamhaithameid*