### PR TITLE
Quill: add tests for v3 token provider and chrome.identity failure paths

### DIFF
--- a/.jules/quill.md
+++ b/.jules/quill.md
@@ -1,0 +1,4 @@
+## 2026-06-27 — Added missing test for v3-api-token-provider
+**Gap Found:** v3 API token provider was completely untested and lacked coverage for chrome.identity.getAuthToken failure paths.
+**Tests Added/Improved:** Created `extension/tests/v3-api-token-provider.test.ts` covering success, missing token, and lastError failures.
+**Learning:** The v3 engines API logic requires separate coverage for its isolated Chrome API wrappers to guarantee failure handling doesn't leak secrets or throw unhandled rejections.

--- a/extension/tests/v3-api-token-provider.test.ts
+++ b/extension/tests/v3-api-token-provider.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChromeIdentityTokenProvider } from '../src/engines/v3/api/token-provider';
+
+describe('ChromeIdentityTokenProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (chrome.runtime as { lastError?: { message: string } }).lastError = undefined;
+    chrome.identity = {
+      getAuthToken: vi.fn(),
+    } as never;
+  });
+
+  it('should return null if chrome.identity is unavailable', async () => {
+    const originalIdentity = chrome.identity;
+    // @ts-expect-error - testing missing API
+    delete chrome.identity;
+
+    const provider = new ChromeIdentityTokenProvider();
+    const result = await provider.getAccessToken(false);
+    expect(result).toBeNull();
+
+    chrome.identity = originalIdentity;
+  });
+
+  it('should return the token when getAuthToken succeeds with string response', async () => {
+    const mockToken = 'ya29.secret_oauth_token';
+    (chrome.identity.getAuthToken as any).mockImplementation(
+      ({ interactive }: any, callback: (token: any) => void) => {
+        expect(interactive).toBe(false);
+        callback(mockToken);
+      }
+    );
+
+    const provider = new ChromeIdentityTokenProvider();
+    const result = await provider.getAccessToken(false);
+    expect(result).toBe(mockToken);
+  });
+
+  it('should return the token when getAuthToken succeeds with object response', async () => {
+    const mockToken = 'ya29.secret_oauth_token_from_object';
+    (chrome.identity.getAuthToken as any).mockImplementation(
+      ({ interactive }: any, callback: (token: any) => void) => {
+        callback({ token: mockToken });
+      }
+    );
+
+    const provider = new ChromeIdentityTokenProvider();
+    const result = await provider.getAccessToken(true);
+    expect(result).toBe(mockToken);
+  });
+
+  it('should pass interactive flag correctly', async () => {
+    (chrome.identity.getAuthToken as any).mockImplementation(
+      ({ interactive }: any, callback: (token: any) => void) => {
+        expect(interactive).toBe(true);
+        callback('token');
+      }
+    );
+
+    const provider = new ChromeIdentityTokenProvider();
+    await provider.getAccessToken(true);
+  });
+
+  it('should return null and not leak token in error logs when lastError is set', async () => {
+    const mockToken = 'ya29.should_not_leak_even_if_returned';
+    (chrome.identity.getAuthToken as any).mockImplementation(
+      ({ interactive }: any, callback: (token: any) => void) => {
+        (chrome.runtime as { lastError?: { message: string } }).lastError = { message: 'OAuth failed' };
+        callback(mockToken);
+      }
+    );
+
+    const provider = new ChromeIdentityTokenProvider();
+    const consoleSpy = vi.spyOn(console, 'error');
+
+    const result = await provider.getAccessToken(false);
+
+    expect(result).toBeNull();
+    // Token must never appear in any log output
+    if (consoleSpy.mock.calls.length > 0) {
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining(mockToken)
+      );
+    }
+  });
+
+  it('should return null when getAuthToken returns empty/invalid values', async () => {
+    const cases = [null, undefined, '', {}, { token: '' }, { other: 'stuff' }];
+
+    for (const testCase of cases) {
+      (chrome.identity.getAuthToken as any).mockImplementationOnce(
+        ({ interactive }: any, callback: (token: any) => void) => {
+          callback(testCase);
+        }
+      );
+
+      const provider = new ChromeIdentityTokenProvider();
+      const result = await provider.getAccessToken(false);
+      expect(result).toBeNull();
+    }
+  });
+
+  it('should handle exceptions thrown by chrome.identity.getAuthToken gracefully', async () => {
+    (chrome.identity.getAuthToken as any).mockImplementation(() => {
+      throw new Error('Unexpected sync error');
+    });
+
+    const provider = new ChromeIdentityTokenProvider();
+    const result = await provider.getAccessToken(false);
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## 🪶 Quill — Extension Unit Tests
**Agent:** Quill | **Day:** Saturday | **Date:** 2026-06-27

---

### 🪶 Gap Found
The `ChromeIdentityTokenProvider` in `extension/src/engines/v3/api/token-provider.ts` was entirely untested. This class interfaces with the sensitive `chrome.identity.getAuthToken` API.

### 🎯 Why It Matters
Without tests, there's no guarantee that failures in token fetching (which are common) won't throw unhandled rejections or leak the token in error messages when `lastError` is set. Given the v3 engine's isolation model, it is critical that these Chrome API wrappers have dedicated unit tests.

### ✅ Tests Added
*   `should return null if chrome.identity is unavailable`: Verifies safety check.
*   `should return the token when getAuthToken succeeds with string response`: Happy path for direct string response.
*   `should return the token when getAuthToken succeeds with object response`: Happy path for object fallback response.
*   `should pass interactive flag correctly`: Verifies proper forwarding of the `interactive` boolean.
*   `should return null and not leak token in error logs when lastError is set`: Crucial security test verifying token isn't leaked on failure.
*   `should return null when getAuthToken returns empty/invalid values`: Input safety checks.
*   `should handle exceptions thrown by chrome.identity.getAuthToken gracefully`: Prevents synchronous crashes.

### 🔬 How to Verify
```bash
cd extension && pnpm run test tests/v3-api-token-provider.test.ts
```

### 📋 Notes
The old v2 `auth-utils.ts` had coverage, but the new v3 architecture split the token fetching into `ChromeIdentityTokenProvider`, which was previously missed in the audit.

---
*PR created automatically by Jules for task [17934866561757899805](https://jules.google.com/task/17934866561757899805) started by @adhamhaithameid*