### PR TITLE
Forge: e2e smoke test doesn't verify download buttons appear on assignment page - add HTML fixture mock test

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,4 @@
+## 2026-03-13 — Added Playwright E2E Test for Classroom Assignment Page
+**Gap Found:** Critical gap identified where no Playwright E2E test verified that the extension loads and correctly injects download buttons (`.cqd-download-btn`) into the DOM on a Classroom assignment page (`tests/e2e/extension-smoke.spec.ts`).
+**Tests Added/Improved:** Appended a test to `tests/e2e/extension-smoke.spec.ts` using `context.route` to mock navigation to a dummy assignment details URL and serve the existing HTML fixture (`classwork-material-post-en.html`). Verified that the `cqd-download-btn` is injected and visible.
+**Learning:** We can reuse HTML fixtures (`tests/fixtures/classroom/*.html`) directly in E2E Playwright tests to simulate Classroom DOM structure by intercepting routes, allowing full browser E2E testing without requiring a live Classroom session or hardcoded auth tokens.

--- a/tests/e2e/extension-smoke.spec.ts
+++ b/tests/e2e/extension-smoke.spec.ts
@@ -25,6 +25,7 @@
 
 import { test, expect, type BrowserContext, chromium } from '@playwright/test';
 import path from 'node:path';
+import fs from 'node:fs';
 
 const EXTENSION_PATH = path.resolve(__dirname, '../../extension/.output/chrome-mv3');
 
@@ -128,6 +129,35 @@ test.describe('Extension Smoke Tests', () => {
     // Note: Chrome shows manifest.json as rendered JSON, not raw
     // We just verify the page loaded something
     expect(manifestText.length).toBeGreaterThan(0);
+
+    await page.close();
+  });
+
+  test('injects download buttons on a Classroom assignment page', async () => {
+    const page = await context.newPage();
+
+    // Intercept navigation to the assignment details page
+    await context.route('https://classroom.google.com/c/course-1/a/work-1/details', async (route) => {
+      const fixturePath = path.resolve(__dirname, '../../extension/tests/fixtures/classroom/classwork-material-post-en.html');
+      const fixtureHtml = fs.readFileSync(fixturePath, 'utf8');
+
+      // Serve the HTML
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: fixtureHtml,
+      });
+    });
+
+    // Navigate to the mock assignment page
+    await page.goto('https://classroom.google.com/c/course-1/a/work-1/details', { waitUntil: 'domcontentloaded' });
+
+    // Wait for the extension to inject the download buttons
+    const downloadButtons = page.locator('.cqd-download-btn');
+    await expect(downloadButtons.first()).toBeVisible({ timeout: 15_000 });
+
+    // There should be one attachment in this fixture
+    expect(await downloadButtons.count()).toBeGreaterThan(0);
 
     await page.close();
   });


### PR DESCRIPTION
**Gap Found:** Critical gap identified where no Playwright E2E test verified that the extension loads and correctly injects download buttons (`.cqd-download-btn`) into the DOM on a Classroom assignment page (`tests/e2e/extension-smoke.spec.ts`).

**Tests Added/Improved:** Appended a test to `tests/e2e/extension-smoke.spec.ts` using `context.route` to mock navigation to a dummy assignment details URL and serve the existing HTML fixture (`classwork-material-post-en.html`). Verified that the `cqd-download-btn` is injected and visible.

**Learning:** We can reuse HTML fixtures (`tests/fixtures/classroom/*.html`) directly in E2E Playwright tests to simulate Classroom DOM structure by intercepting routes, allowing full browser E2E testing without requiring a live Classroom session or hardcoded auth tokens.

---
*PR created automatically by Jules for task [14399054414338055685](https://jules.google.com/task/14399054414338055685) started by @adhamhaithameid*