### PR TITLE
Compass: routes.render.test.ts missing explicit test for absolute og:image URL

### DIFF
--- a/.jules/compass.md
+++ b/.jules/compass.md
@@ -1,0 +1,5 @@
+
+## 2023-10-28 — Added og:image absolute URL test
+**Gap Found:** The `routes.render.test.ts` test did not assert that the `og:image` meta tag is an absolute URL, leading to potential silent SEO failures for social sharing.
+**Tests Added/Improved:** `website/src/routes/routes.render.test.ts` now covers absolute `og:image` URL checking on standard pages like `FaqPage`.
+**Learning:** We need to explicitly check that SEO meta properties are rendered as expected and are completely valid URLs (especially absolute ones), instead of just checking for existence.

--- a/website/src/routes/routes.render.test.ts
+++ b/website/src/routes/routes.render.test.ts
@@ -154,6 +154,14 @@ describe('route render smoke coverage', () => {
     expect(html).toContain('Zero personal data');
   });
 
+  it('renders FAQ page with absolute og:image URL for correct social sharing', () => {
+    const { head } = render(FaqPage);
+    const ogImageMatch = head.match(/<meta[^>]+property="og:image"[^>]+content="([^"]+)"/i) || head.match(/<meta[^>]+content="([^"]+)"[^>]+property="og:image"/i);
+
+    expect(ogImageMatch).toBeTruthy();
+    expect(ogImageMatch?.[1]).toMatch(/^https:\/\//);
+  });
+
   it('renders FAQ page with multiple sections and known questions', () => {
     const { body, head } = render(FaqPage);
     const html = squish(body);


### PR DESCRIPTION
## 🧭 Compass — Website Tests
**Agent:** Compass | **Day:** Saturday | **Date:** 2023-10-28

---

### 🧭 Gap Found
The route render test (`website/src/routes/routes.render.test.ts`) tested rendering and the existence of the `og:image` tag, but did not actually verify that the tag contained an absolute URL starting with `https://`. 

### 🎯 Why It Matters
A relative `og:image` URL breaks social media sharing previews, which is a silent SEO/growth failure. Checking that the property exists isn't enough; it explicitly needs to be an absolute URL for platforms like Twitter and Facebook to correctly scrape and render the card.

### ✅ Tests Added
- `renders FAQ page with absolute og:image URL for correct social sharing` - Verified `og:image` content starts with `https://` on a standard page (`FaqPage`).

### 🔬 How to Verify
`cd website && pnpm run test:routes` — all route render tests should pass.

### 📋 Notes
In future testing runs, we should verify that `twitter:image` also contains an absolute URL, and ensure our standard `<SeoMeta />` component fallback uses an absolute URL generated from `SITE_URL`.

---
*PR created automatically by Jules for task [4816583724515703211](https://jules.google.com/task/4816583724515703211) started by @adhamhaithameid*