### PR TITLE
Weave: add chrome.runtime.lastError check to chrome.runtime.sendMessage calls

### DIFF
--- a/.jules/weave.md
+++ b/.jules/weave.md
@@ -1,0 +1,5 @@
+
+## 2026-06-28 — Add chrome.runtime.lastError check for chrome.runtime.sendMessage calls
+**Finding:** Found multiple `chrome.runtime.sendMessage` calls across content scripts without callbacks checking `chrome.runtime.lastError`, leading to unhandled promise rejections or console warnings when the background service worker is inactive or disconnected.
+**Action:** Appended an empty callback `() => { const _ = chrome.runtime.lastError; }` to `sendMessage` calls in `observers.ts`, `message-handler.ts`, `download-handler.ts`, `download_all.content.ts`, `drive_bypass.content.ts`, and `drive_bypass_register.content.ts`. Updated `content-message-handler.test.ts`, `content-observers.test.ts`, and `cancel.test.ts` to expect this callback in `toHaveBeenCalledWith` assertions.
+**Learning:** Chrome Manifest V3 service workers can terminate frequently. All async message-passing from content scripts must explicitly read `chrome.runtime.lastError` via a callback to prevent runtime exceptions if the target background script is unavailable.

--- a/extension/entrypoints/content/download-handler.ts
+++ b/extension/entrypoints/content/download-handler.ts
@@ -59,7 +59,7 @@ export async function handleCancelClick(button: HTMLButtonElement): Promise<void
         chrome.runtime.sendMessage({
           type: 'CQD_CANCEL_DOWNLOAD',
           requestId: pending.requestId,
-        });
+        }, () => { const _ = chrome.runtime.lastError; });
       } catch (err) {
         // Error sending cancel message
       }

--- a/extension/entrypoints/content/message-handler.ts
+++ b/extension/entrypoints/content/message-handler.ts
@@ -126,7 +126,7 @@ export function initContentScript(): void {
 
   // Request icon update
   try {
-    chrome.runtime.sendMessage({ type: 'CQD_UPDATE_ICON' });
+    chrome.runtime.sendMessage({ type: 'CQD_UPDATE_ICON' }, () => { const _ = chrome.runtime.lastError; });
   } catch { /* ignore */ }
 
   // Subscribe to global enable/disable state

--- a/extension/entrypoints/content/observers.ts
+++ b/extension/entrypoints/content/observers.ts
@@ -271,7 +271,7 @@ export function applyEffectiveState(enabled: boolean): void {
       chrome.runtime.sendMessage({
         type: 'CQD_EFFECTIVE_STATE_CHANGED',
         enabled,
-      });
+      }, () => { const _ = chrome.runtime.lastError; });
     } catch { /* ignore */ }
   }
 }

--- a/extension/entrypoints/download_all.content.ts
+++ b/extension/entrypoints/download_all.content.ts
@@ -1314,7 +1314,7 @@ function handleCancelAllClick(group: GroupState): void {
       requestIdFoundCount++;
       if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
         try {
-          chrome.runtime.sendMessage({type: 'CQD_CANCEL_DOWNLOAD', requestId });
+          chrome.runtime.sendMessage({type: 'CQD_CANCEL_DOWNLOAD', requestId }, () => { const _ = chrome.runtime.lastError; });
           messagesSentCount++;
         } catch (err) {
           // Failed to send cancel message

--- a/extension/entrypoints/drive_bypass.content.ts
+++ b/extension/entrypoints/drive_bypass.content.ts
@@ -75,7 +75,7 @@ function startBypassFeature() {
     ) {
       auth403Reported = true;
       try {
-        chrome.runtime.sendMessage({ type: 'CQD_403_SEEN' });
+        chrome.runtime.sendMessage({ type: 'CQD_403_SEEN' }, () => { const _ = chrome.runtime.lastError; });
       } catch {
         /* ignore */
       }
@@ -210,7 +210,7 @@ function handleVirusBypassClick(): boolean {
 function notifySuccessFlood() {
   const send = () => {
     try {
-      chrome.runtime.sendMessage({ type: 'CQD_BYPASS_SUCCESS' });
+      chrome.runtime.sendMessage({ type: 'CQD_BYPASS_SUCCESS' }, () => { const _ = chrome.runtime.lastError; });
     } catch {
       /* ignore */
     }

--- a/extension/entrypoints/drive_bypass_register.content.ts
+++ b/extension/entrypoints/drive_bypass_register.content.ts
@@ -23,7 +23,7 @@ function registerBypassUrl(): void {
   if (url === lastUrl) return;
   lastUrl = url;
   try {
-    chrome.runtime.sendMessage({ type: 'CQD_REGISTER_BYPASS_URL', url });
+    chrome.runtime.sendMessage({ type: 'CQD_REGISTER_BYPASS_URL', url }, () => { const _ = chrome.runtime.lastError; });
   } catch {
     // ignore
   }

--- a/extension/tests/cancel.test.ts
+++ b/extension/tests/cancel.test.ts
@@ -125,12 +125,12 @@ describe('Cancel Message Passing', () => {
     chrome.runtime.sendMessage({
       type: 'CQD_CANCEL_DOWNLOAD',
       requestId,
-    });
+    }, () => { const _ = chrome.runtime.lastError; });
 
     expect(sendMessageSpy).toHaveBeenCalledWith({
       type: 'CQD_CANCEL_DOWNLOAD',
       requestId: 'test-req-123',
-    });
+    }, expect.any(Function));
   });
 
   it('should include correct message type', () => {

--- a/extension/tests/content-message-handler.test.ts
+++ b/extension/tests/content-message-handler.test.ts
@@ -196,7 +196,7 @@ describe('content message handler', () => {
   it('initContentScript wires icon update, subscription, and listener setup only on classroom pages', async () => {
     const classroom = await loadMessageHandler(true);
     classroom.mod.initContentScript();
-    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'CQD_UPDATE_ICON' });
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'CQD_UPDATE_ICON' }, expect.any(Function));
     expect(classroom.subscribeSpy).toHaveBeenCalled();
     expect((chrome.runtime.onMessage.addListener as any).mock.calls.length).toBeGreaterThan(0);
 

--- a/extension/tests/content-observers.test.ts
+++ b/extension/tests/content-observers.test.ts
@@ -174,14 +174,14 @@ describe('content/observers', () => {
     expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({
       type: 'CQD_EFFECTIVE_STATE_CHANGED',
       enabled: true,
-    }));
+    }), expect.any(Function));
 
     mod.stopCQD();
     expect(state.initialized).toBe(false);
     expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({
       type: 'CQD_EFFECTIVE_STATE_CHANGED',
       enabled: false,
-    }));
+    }), expect.any(Function));
   });
 
   it('deduplicates roots in MutationObserver callback', async () => {


### PR DESCRIPTION
### 🕸️ Weave — Content Scripts
**Agent:** Weave | **Day:** Sunday | **Date:** 2026-06-28

---

### 🚨 Severity
HIGH

### 🕸️ Finding
Found multiple `chrome.runtime.sendMessage` calls across content scripts without callbacks checking `chrome.runtime.lastError`, leading to unhandled promise rejections or console warnings when the background service worker is inactive or disconnected. This is particularly problematic in Manifest V3 where background scripts frequently terminate and restarts can take several ms, causing fire-and-forget messages to fail.

### 🎯 Impact
Unhandled promise rejections and console warnings due to disconnected/inactive background script. Can lead to "Unchecked runtime.lastError" or "Uncaught (in promise)" errors. This causes noisy logs and potentially unpredictable behavior in the content script if the exception bubbles up.

### 🔧 Fix Applied
Appended an empty callback `() => { const _ = chrome.runtime.lastError; }` to `sendMessage` calls in `observers.ts`, `message-handler.ts`, `download-handler.ts`, `download_all.content.ts`, `drive_bypass.content.ts`, and `drive_bypass_register.content.ts`. Updated `content-message-handler.test.ts`, `content-observers.test.ts`, and `cancel.test.ts` to expect this callback in `toHaveBeenCalledWith` assertions by using `expect.any(Function)`.

### ✅ Verification
Run tests:
```bash
cd extension && pnpm run test
```

### 📋 Notes
Chrome Manifest V3 service workers can terminate frequently. All async message-passing from content scripts must explicitly read `chrome.runtime.lastError` via a callback to prevent runtime exceptions if the target background script is unavailable.

---
*PR created automatically by Jules for task [4281550481952865265](https://jules.google.com/task/4281550481952865265) started by @adhamhaithameid*