### PR TITLE
Fetch: classroom API client lacks timeout and explicit error handling

### DIFF
--- a/.jules/fetch.md
+++ b/.jules/fetch.md
@@ -1,0 +1,4 @@
+## 2023-10-24 — Added robust error handling and timeout to Classroom API client
+**Finding:** The `fetch` call in `classroom-api-client.ts` had no timeout, lacked specific handling for HTTP error codes (401, 403, 429), and called `response.json()` without a try/catch block. This could cause silent failures, uncaught promise rejections on malformed responses, or requests that hang indefinitely.
+**Action:** Updated `classroom-api-client.ts` to implement a 15-second timeout using an `AbortController`. Added specific error checks and descriptive error messages for 401, 403, and 429 response codes. Wrapped `fetch` and `response.json()` calls in try/catch blocks for resilience.
+**Learning:** `fetch` calls in the extension must be written defensively: always use `AbortController` for timeouts, explicitly handle distinct failure states (e.g., auth vs network errors), and wrap parsing logic in try/catch to protect the engine from unexpected API responses.

--- a/extension/src/engines/v3/api/classroom-api-client.ts
+++ b/extension/src/engines/v3/api/classroom-api-client.ts
@@ -125,18 +125,47 @@ export class GoogleClassroomApiClient implements ClassroomApiClient {
       }
       if (pageToken) requestUrl.searchParams.set('pageToken', pageToken);
 
-      const response = await fetch(requestUrl.toString(), {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        signal,
-      });
-      if (!response.ok) {
-        return submissions;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15000);
+      const onAbort = () => controller.abort();
+      if (signal) {
+        if (signal.aborted) controller.abort();
+        else signal.addEventListener('abort', onAbort);
       }
 
-      const payload = await response.json() as GoogleClassroomStudentSubmissionResponse;
+      let response: Response;
+      try {
+        response = await fetch(requestUrl.toString(), {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeoutId);
+        if (signal) signal.removeEventListener('abort', onAbort);
+      }
+
+      if (response.status === 401) {
+        throw new Error('AuthExpiredError: Token expired — refresh required');
+      }
+      if (response.status === 403) {
+        throw new Error('PermissionError: Insufficient permissions for this resource');
+      }
+      if (response.status === 429) {
+        throw new Error('RateLimitError: API rate limit exceeded');
+      }
+      if (!response.ok) {
+        throw new Error(`APIError: Classroom API error ${response.status}`);
+      }
+
+      let payload: GoogleClassroomStudentSubmissionResponse;
+      try {
+        payload = await response.json() as GoogleClassroomStudentSubmissionResponse;
+      } catch {
+        throw new Error('ParseError: Failed to parse Classroom API response');
+      }
       const batch = (payload.studentSubmissions || [])
         .map((submission) => mapSubmission(submission, context.authUser))
         .filter((submission): submission is ClassroomApiStudentSubmission => !!submission);


### PR DESCRIPTION
## 📡 Fetch — API Engines
**Agent:** Fetch | **Day:** Tuesday | **Date:** 2023-10-24

---

### 🚨 Severity
HIGH

### 📡 Finding
The `fetch` call in `classroom-api-client.ts` had no timeout, lacked specific handling for HTTP error codes (401, 403, 429), and called `response.json()` without a try/catch block. This could cause silent failures, uncaught promise rejections on malformed responses, or requests that hang indefinitely.

### 🎯 Impact
Without timeouts, network requests can stall indefinitely, hanging the application state. Unhandled HTTP statuses lead to silent data omission, and unprotected `response.json()` calls crash the promise chain if Google's API returns non-JSON responses (e.g. gateway timeouts).

### 🔧 Fix Applied
- Implemented a 15-second timeout using an internal `AbortController` and `setTimeout`.
- Managed synchronization with an optional, caller-provided `AbortSignal` safely to avoid masking genuine abort events.
- Added explicit HTTP status checks that throw detailed errors for 401 (AuthExpiredError), 403 (PermissionError), and 429 (RateLimitError).
- Wrapped `response.json()` in a `try/catch` that throws a `ParseError` on failure.

### ✅ Verification
- `pnpm run compile` in `extension/` passes.
- `pnpm run test --reporter=verbose v3` in `extension/` passes.
- `pnpm run build` in `extension/` passes.
- `pnpm run test:smoke` at the workspace root passes.
- `extension/src/engines/v3/api/classroom-api-client.ts` was manually verified for correct logic.

### 📋 Notes
This fix properly surfaces API failure reasons so downstream engine logic (e.g. `discovery-service`) can eventually implement retry or cache-busting behaviors.

---
*PR created automatically by Jules for task [2750667694490620816](https://jules.google.com/task/2750667694490620816) started by @adhamhaithameid*