### PR TITLE
Flare: parallelize sequential await calls for website console snapshot data

### DIFF
--- a/.jules/flare.md
+++ b/.jules/flare.md
@@ -1,0 +1,5 @@
+
+## 2026-06-29 — Parallelized sequential awaits for Website Console snapshot data
+**Finding:** Sequential `await` calls were used to fetch `doStatus` and read `cachedRaw`/`kvRaw` from snapshot cache, blocking the event loop longer than necessary in the admin website console summary and snapshot endpoints.
+**Action:** Replaced sequential awaits with `Promise.all()` in `cloudflare-worker/src/index.ts` to fetch DO status and KV snapshot in parallel.
+**Learning:** Always look for independent async calls (like separate storage layer calls or external API calls) and run them concurrently using `Promise.all()` to improve edge latency.

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1647,8 +1647,10 @@ async function handleWebsiteConsoleAdminEndpoint(
 
   try {
     if (pathname === "/admin/website/console/summary") {
-      const doStatus = await fetchDoWebsiteStatus(env);
-      const cachedRaw = await readSiteSnapshotCache(env);
+      const [doStatus, cachedRaw] = await Promise.all([
+        fetchDoWebsiteStatus(env),
+        readSiteSnapshotCache(env)
+      ]);
       let cachedSnapshot: Record<string, unknown> | null = null;
       if (cachedRaw) {
         try {
@@ -1812,8 +1814,10 @@ async function handleWebsiteConsoleAdminEndpoint(
     }
 
     if (pathname === "/admin/website/console/snapshot/raw") {
-      const doStatus = await fetchDoWebsiteStatus(env);
-      const kvRaw = await readSiteSnapshotCache(env);
+      const [doStatus, kvRaw] = await Promise.all([
+        fetchDoWebsiteStatus(env),
+        readSiteSnapshotCache(env)
+      ]);
       let kvParsed: Record<string, unknown> | null = null;
       if (kvRaw) {
         try {


### PR DESCRIPTION
## 🌩️ Flare — Cloudflare Worker Security & Performance
**Agent:** Flare | **Day:** Monday | **Date:** 2026-06-29

---

### 🚨 Severity
[PERFORMANCE]

### 🌩️ Finding
Sequential `await` calls in `cloudflare-worker/src/index.ts` within `handleWebsiteConsoleAdminEndpoint` (around line 1650 and 1815) when fetching dashboard summary and snapshot raw data.

### 🎯 Impact
Latency is impacted by making `fetchDoWebsiteStatus(env)` and `readSiteSnapshotCache(env)` sequentially. Both can be fetched independently.

### 🔧 Fix Applied
Refactored these sequential `await` calls to be parallel using `Promise.all([fetchDoWebsiteStatus(env), readSiteSnapshotCache(env)])`, avoiding unnecessary blocking of the event loop.

### ✅ Verification
Tested locally:
```bash
cd cloudflare-worker && pnpm run typecheck && pnpm run lint && pnpm run test
pnpm run test:smoke
```

### 📋 Notes
Gate should note this performance improvement on the Website Console Admin endpoint.

---
*PR created automatically by Jules for task [12073393517688425985](https://jules.google.com/task/12073393517688425985) started by @adhamhaithameid*