### PR TITLE
Lumen: add explicit width and height to icon images to prevent CLS

### DIFF
--- a/.jules/lumen.md
+++ b/.jules/lumen.md
@@ -1,0 +1,4 @@
+## 2026-07-01 — Fixed CLS from missing image dimensions on icon images
+**Finding:** Multiple `<img class="l2-cta-icon">` and `<img class="un-browser-icon">` elements lacked explicit `width` and `height` attributes, causing Cumulative Layout Shift (CLS) during page load. Estimated impact: slight CLS improvement.
+**Action:** Added explicit `width="22" height="22"` (or `width="20" height="20"`) to the affected icons in `+page.svelte` across the `overview`, `overview-editor`, and `uninstall` routes.
+**Learning:** Svelte component rendering respects CSS dimensions, but providing explicit HTML width/height attributes for browser icons prevents initial layout recalculation and shifts before CSS fully loads.

--- a/website/src/routes/overview-editor/+page.svelte
+++ b/website/src/routes/overview-editor/+page.svelte
@@ -1501,7 +1501,7 @@
             rel="noopener noreferrer"
             on:click={() => trackInstallClick('hero_install')}
           >
-            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" />
+            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
             {#if b === detectedBrowser}Install for {browserDisplayName(b)}{:else}{browserDisplayName(b)}{/if}
           </a>
         {/each}
@@ -1915,7 +1915,7 @@
                         rel="noopener noreferrer"
                         on:click={() => trackInstallClick('map_prompt_install')}
                       >
-                        <img src="{base}/images/{detectedBrowser}.svg" alt="" class="l2-cta-icon" />
+                        <img src="{base}/images/{detectedBrowser}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
                         Install for {browserDisplayName(detectedBrowser)}
                       </a>
                     </div>
@@ -2014,7 +2014,7 @@
             rel="noopener noreferrer"
             on:click={() => trackInstallClick('final_install')}
           >
-            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" />
+            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
             {#if b === detectedBrowser}Install for {browserDisplayName(b)}{:else}{browserDisplayName(b)}{/if}
           </a>
         {/each}

--- a/website/src/routes/overview/+page.svelte
+++ b/website/src/routes/overview/+page.svelte
@@ -1602,7 +1602,7 @@
             rel="noopener noreferrer"
             on:click={() => trackInstallClick('hero_install')}
           >
-            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" />
+            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
             {#if b === detectedBrowser}Install for {browserDisplayName(b)}{:else}{browserDisplayName(b)}{/if}
           </a>
         {/each}
@@ -2024,7 +2024,7 @@
                         rel="noopener noreferrer"
                         on:click={() => trackInstallClick('map_prompt_install')}
                       >
-                        <img src="{base}/images/{detectedBrowser}.svg" alt="" class="l2-cta-icon" />
+                        <img src="{base}/images/{detectedBrowser}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
                         Install for {browserDisplayName(detectedBrowser)}
                       </a>
                     </div>
@@ -2123,7 +2123,7 @@
             rel="noopener noreferrer"
             on:click={() => trackInstallClick('final_install')}
           >
-            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" />
+            <img src="{base}/images/{b}.svg" alt="" class="l2-cta-icon" width="22" height="22" />
             {#if b === detectedBrowser}Install for {browserDisplayName(b)}{:else}{browserDisplayName(b)}{/if}
           </a>
         {/each}

--- a/website/src/routes/uninstall/+page.svelte
+++ b/website/src/routes/uninstall/+page.svelte
@@ -283,7 +283,7 @@
               class:detected={isDetected}
               on:click={() => trackReinstallClick(browser)}
             >
-              <img src="{base}/images/{browser}.svg" alt="" class="un-browser-icon" />
+              <img src="{base}/images/{browser}.svg" alt="" class="un-browser-icon" width="20" height="20" />
               {#if isDetected}Reinstall for {browserDisplayName(browser)}{:else}{browserDisplayName(browser)}{/if}
             </a>
           {/each}


### PR DESCRIPTION
## 💡 Lumen — Website Performance
**Agent:** Lumen | **Day:** Wednesday

---

### ⚡ Performance Finding
Multiple browser icon `<img>` elements (`.l2-cta-icon` and `.un-browser-icon`) across `+page.svelte` in `overview`, `overview-editor`, and `uninstall` routes lacked explicit `width` and `height` attributes. This introduces a Cumulative Layout Shift (CLS) risk as the browser recalculates layout when CSS loads and forces their dimensions to `22x22` or `20x20`.

### 📊 Estimated Impact
Slight CLS improvement across landing and uninstall pages. Eliminates minor layout shifts during page rendering.

### 🔧 Optimisation Applied
Added `width="22" height="22"` to `.l2-cta-icon` elements and `width="20" height="20"` to `.un-browser-icon` elements.

### ✅ Verification
- `pnpm run check` in `website/` passes.
- `pnpm run build` in `website/` passes.
- `pnpm run test:smoke` at repo root passes.

### 📋 Notes
Svelte component rendering respects CSS dimensions, but providing explicit HTML width/height attributes for browser icons prevents initial layout recalculation and shifts before CSS fully loads.

---
*PR created automatically by Jules for task [1133227759442354122](https://jules.google.com/task/1133227759442354122) started by @adhamhaithameid*