### PR TITLE
Aria: layout missing skip-to-main-content link — keyboard users cannot skip nav

### DIFF
--- a/.jules/aria.md
+++ b/.jules/aria.md
@@ -1,0 +1,4 @@
+## 2026-07-01 — Added skip navigation link
+**Finding:** No skip navigation link — keyboard users tab through entire nav on every page (WCAG 2.4.1 Bypass Blocks)
+**Action:** Added a visually hidden skip-to-main-content link at the top of +layout.svelte that becomes visible on focus. Updated main element with id='main-content' and tabindex='-1'.
+**Learning:** SvelteKit global layouts need a skip link to bypass navigation headers, improving keyboard accessibility.

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -151,6 +151,8 @@
 <LoadingScreen />
 
 <div class="site-shell" class:o2-fullscreen={hideChrome}>
+  <a href="#main-content" class="skip-nav">Skip to main content</a>
+
   {#if !hideChrome}
   <header class="l2-nav-shell">
     <div class="l2-nav-inner l2-nav-fullwidth">
@@ -238,6 +240,8 @@
   {/if}
 
   <main
+    id="main-content"
+    tabindex="-1"
     class:site-main={!isOverviewStyleRoute && !hideChrome}
     class:site-main-overview-style={isOverviewStyleRoute && !hideChrome}
     class:l2-wrap={!isOverviewStyleRoute && !hideChrome}
@@ -282,6 +286,21 @@
   main {
     flex: 1;
     min-height: 0;
+  }
+
+  .skip-nav {
+    position: absolute;
+    top: -100%;
+    left: 0;
+    padding: 0.5rem 1rem;
+    background: var(--gc-green);
+    color: white;
+    z-index: 9999;
+    text-decoration: none;
+    font-weight: 600;
+  }
+  .skip-nav:focus {
+    top: 0;
   }
 
   .site-shell {


### PR DESCRIPTION
### ♿ WCAG Violation
WCAG 2.1 AA — 2.4.1 Bypass Blocks

### 🔍 Finding
`website/src/routes/+layout.svelte` — The layout was missing a skip navigation link, forcing keyboard and screen reader users to tab through all navigation elements on every single page load before reaching the main content.

### 👤 User Impact
Keyboard-only users and screen reader users are significantly slowed down, having to manually tab through the header links repeatedly on every navigation.

### 🔧 Fix Applied
- Added a visually hidden "Skip to main content" link (`.skip-nav`) at the very top of `+layout.svelte`.
- Configured `.skip-nav:focus` to make the link visible (`top: 0`) when tabbed to.
- Added `id="main-content"` and `tabindex="-1"` to the `<main>` element so it can receive programmatic focus when the skip link is activated, correctly bypassing the header blocks.

### ✅ Verification
- Type check: `cd website && pnpm check` passes
- Build: `cd website && pnpm build` passes
- Testing: `cd website && pnpm test:routes` and root `pnpm run test:smoke` pass
- Manual keyboard nav steps: Tab once on page load -> Skip link becomes visible at the top -> Press Enter -> Focus successfully moves to the main content area.

### 📋 Notes
In future runs, verify if individual long pages require their own internal skip links, though this layout-level skip link covers the global navigation block.

---
*PR created automatically by Jules for task [11847186677822625580](https://jules.google.com/task/11847186677822625580) started by @adhamhaithameid*