### PR TITLE
Ember: pulse effect ignores prefers-reduced-motion — bypass animation for reduced motion users

### DIFF
--- a/.jules/ember.md
+++ b/.jules/ember.md
@@ -1,0 +1,4 @@
+## 2026-01-24 — Pulse effect respects prefers-reduced-motion
+**Finding:** Pulse effect in `triggerPulseEffect` was ignoring user's system accessibility setting for `prefers-reduced-motion`.
+**Action:** Added a `matchMedia('(prefers-reduced-motion: reduce)')` check in `triggerPulseEffect` to return early and skip the pulse animation, conforming to WCAG 2.1 AA 2.3.3.
+**Learning:** Always check `typeof window.matchMedia === 'function'` before checking media queries to ensure tests and unsupported environments don't crash.

--- a/extension/entrypoints/content/pulse-effect.ts
+++ b/extension/entrypoints/content/pulse-effect.ts
@@ -111,6 +111,14 @@ export function unmarkTargetElements(post: HTMLElement): void {
  * Includes debounce to prevent multiple clicks during animation.
  */
 export function triggerPulseEffect(post: HTMLElement, type: PulseType): void {
+  // Respect user's motion preference — WCAG 2.1 AA 2.3.3
+  if (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ) {
+    return;
+  }
+
   // animations in js instead of css?? sacrilege
   const ANIMATION_DURATION = 1500; // Match CSS animation duration
   const DEBOUNCE_ATTR = 'data-cqd-animating';


### PR DESCRIPTION
## 🔥 Ember — Extension UX Micro-Improvements
**Agent:** Ember | **Day:** Wednesday | **Date:** 2026-01-24

---

### 🔥 UX Finding
The pulse effect in `triggerPulseEffect` (used for comment/edit/both badges) was ignoring user's system accessibility setting for `prefers-reduced-motion`.

### 👤 User Impact
Users with vestibular disorders must not be subjected to motion they didn't ask for. Currently, the pulse effect ignores their OS-level preferences, leading to a jarring and inaccessible experience.

### 🔧 Improvement Applied
Added a `matchMedia('(prefers-reduced-motion: reduce)')` check in `triggerPulseEffect` to return early and skip the pulse animation, conforming to WCAG 2.1 AA 2.3.3. Safely wrapped the check with `typeof window.matchMedia === 'function'` to avoid crashing in JSDOM environments.

### ✅ Verification
- Ran Vitest `content-pulse` suite.
- Built extension (`pnpm run build`).
- Ran smoke tests (`pnpm run test:smoke`).

### 📋 Notes
Also added an entry to `.jules/ember.md`.

---
*PR created automatically by Jules for task [17849224627037471505](https://jules.google.com/task/17849224627037471505) started by @adhamhaithameid*