### PR TITLE
Signal: block internal email preview pages from indexing

### DIFF
--- a/.jules/signal.md
+++ b/.jules/signal.md
@@ -1,0 +1,4 @@
+## 2024-03-04 — Blocked internal/draft emails pages from being indexed
+**Finding:** Internal draft pages `/emails` and `/emails2` lacked `noindex` directives and were missing from `robots.txt` Disallow list, risking accidental search engine discovery and duplicate content indexing.
+**Action:** Added `noindex={true}` to the `<SeoMeta>` component in both `website/src/routes/emails/+page.svelte` and `website/src/routes/emails2/+page.svelte`. Also added `Disallow: /emails` and `Disallow: /emails2` to `website/src/routes/robots.txt/+server.ts`.
+**Learning:** Always ensure that internal UI preview pages or drafts explicitly use `noindex={true}` and are added to `robots.txt` since crawler discovery might leak internal tools or hurt overall SEO scores via thin/duplicate content.

--- a/website/src/routes/emails/+page.svelte
+++ b/website/src/routes/emails/+page.svelte
@@ -12,6 +12,7 @@
   description="Browser preview of the Classroom Quick Downloader advertisement email."
   path="/emails"
   keywords="classroom quick downloader email, classroom extension email ad"
+  noindex={true}
 />
 
 <section class="emails-page">

--- a/website/src/routes/emails2/+page.svelte
+++ b/website/src/routes/emails2/+page.svelte
@@ -75,6 +75,7 @@
   description="Svelte-native email preview for Classroom Quick Downloader with consistent cross-device rendering."
   path="/emails2"
   keywords="classroom quick downloader email preview, svelte email page"
+  noindex={true}
 />
 
 <section class="emails2-page" aria-label="Classroom Quick Downloader email preview">

--- a/website/src/routes/robots.txt/+server.ts
+++ b/website/src/routes/robots.txt/+server.ts
@@ -16,6 +16,8 @@ Disallow: /uninstall
 Disallow: /404
 Disallow: /overview-editor
 Disallow: /landing2
+Disallow: /emails
+Disallow: /emails2
 
 Sitemap: ${siteUrl}/sitemap.xml
 ${host ? `Host: ${host}\n` : ''}


### PR DESCRIPTION
## 📶 Signal — Website SEO
**Agent:** Signal | **Day:** Wednesday | **Date:** 2024-03-04

---

### 📶 SEO Finding
Internal draft preview pages (`/emails` and `/emails2`) were lacking `noindex` directives and were not explicitly disallowed in `robots.txt`. This creates a risk of search engines discovering, crawling, and indexing these pages which might lead to duplicate content issues or leaking internal tools.

### 🎯 Search Impact
Prevents search engines from crawling and indexing internal, low-quality test content. This ensures the site's crawl budget is focused on important public pages and protects overall site quality signals by avoiding thin or duplicate content issues.

### 🔧 Fix Applied
- Added `noindex={true}` to the `<SeoMeta>` component in `website/src/routes/emails/+page.svelte`.
- Added `noindex={true}` to the `<SeoMeta>` component in `website/src/routes/emails2/+page.svelte`.
- Added `Disallow: /emails` and `Disallow: /emails2` to `website/src/routes/robots.txt/+server.ts`.

### ✅ Verification
- Ran Svelte check, component tests, smoke tests, and verified successful build without type errors via `pnpm run check && pnpm run test && pnpm run build`.
- Visually checked `robots.txt` generation in source code and ensured it includes the new directives.
- Logged the finding and fix to `.jules/signal.md`.

### 📋 Notes
Future agents should ensure that any newly added internal/preview paths are also restricted using similar `noindex` tags and `robots.txt` disallows.

---
*PR created automatically by Jules for task [14527703540780720197](https://jules.google.com/task/14527703540780720197) started by @adhamhaithameid*