### PR TITLE
Stamp: release-version.manual.json out of sync with oracle-backend/package.json

### DIFF
--- a/.jules/stamp.md
+++ b/.jules/stamp.md
@@ -1,0 +1,7 @@
+
+## 2025-03-05 — Synced oracleBackend version across components
+**Extension Version (canonical):** 1.5.5
+**Files Checked:** data/changelog/release-version.manual.json, website/src/lib/content/release-version.manual.generated.json, website/src/lib/content/release-version.manual.generated.ts, oracle-backend/package.json
+**Discrepancies Found:** `oracleBackend` version was `5.0.0` in `data/changelog/release-version.manual.json` and generated website files, but `6.0.0` in `oracle-backend/package.json`.
+**Action Taken:** PR created. Updated `oracleBackend` to `6.0.0` in `data/changelog/release-version.manual.json`, `website/src/lib/content/release-version.manual.generated.json`, and `website/src/lib/content/release-version.manual.generated.ts`.
+**Learning:** Manual JSON files referencing cross-component versions might drift when backend or worker components undergo separate version bumps, especially when not auto-syncing on release.

--- a/data/changelog/release-version.manual.json
+++ b/data/changelog/release-version.manual.json
@@ -1,6 +1,6 @@
 {
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 }

--- a/website/src/lib/content/release-version.manual.generated.json
+++ b/website/src/lib/content/release-version.manual.generated.json
@@ -2,6 +2,6 @@
   "generatedAt": 1781017451093,
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 }

--- a/website/src/lib/content/release-version.manual.generated.ts
+++ b/website/src/lib/content/release-version.manual.generated.ts
@@ -3,6 +3,6 @@ export const WEBSITE_MANUAL_RELEASE_VERSION = {
   "generatedAt": 1781017451093,
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 } as const;


### PR DESCRIPTION
## 🏷️ Stamp — Version Consistency
**Agent:** Stamp | **Day:** Wednesday | **Date:** 2025-03-05

---

### 🏷️ Discrepancy Found
The `oracleBackend` version was explicitly defined as `5.0.0` in `data/changelog/release-version.manual.json`, `website/src/lib/content/release-version.manual.generated.json`, and `website/src/lib/content/release-version.manual.generated.ts`. However, the `oracle-backend` package version in `oracle-backend/package.json` had been bumped to `6.0.0`. 

### ✅ Fix Applied
Updated the `oracleBackend` value in the three out-of-sync files to strictly match `6.0.0`:
- `data/changelog/release-version.manual.json`: `5.0.0` -> `6.0.0`
- `website/src/lib/content/release-version.manual.generated.json`: `5.0.0` -> `6.0.0`
- `website/src/lib/content/release-version.manual.generated.ts`: `5.0.0` -> `6.0.0`

### 🔬 Verification
Run the following commands to verify:
```bash
cat data/changelog/release-version.manual.json
cat website/src/lib/content/release-version.manual.generated.json
cat website/src/lib/content/release-version.manual.generated.ts
node -e "console.log(require('./oracle-backend/package.json').version)"
```
Also, ensure tests are green:
```bash
cd website && pnpm run check && pnpm run test
```

### 📋 Notes
The cross-component version mappings manually specified in JSON files can drift easily when sub-components undergo major/minor version bumps and the release automation doesn't catch them. Continue to monitor these cross-sync configuration files.

---
*PR created automatically by Jules for task [6061178880778004752](https://jules.google.com/task/6061178880778004752) started by @adhamhaithameid*