### PR TITLE
Sage: Feature suggestions for Download-All Filtering and History Visibility

### DIFF
--- a/.jules/sage.md
+++ b/.jules/sage.md
@@ -1,0 +1,4 @@
+## 2026-07-02 — Download All Filtering and History Visibility
+**Issues Filed:** Sage: add per-file-type filter to download-all, Sage: show recent download history in popup
+**Rationale:** Both areas touch core functionality that reduces friction in bulk workflows and addresses visibility gaps without requiring new permissions.
+**Areas for Next Run:** Failed download retry mechanisms, cross-assignment bulk downloads.

--- a/sage-issue-1.md
+++ b/sage-issue-1.md
@@ -1,0 +1,43 @@
+---
+title: "Sage: add per-file-type filter to download-all"
+---
+
+## 🌿 Sage — Extension Feature Suggestion
+**Agent:** Sage | **Day:** Thursday | **Date:** 2026-07-02
+
+---
+
+### 👤 User Story
+As a teacher, I want to filter the "Download All" action by file type (e.g., only download PDFs or Google Docs), so that I don't clutter my local machine with irrelevant file types like supplementary images or instructions when collecting student submissions.
+
+### 🔍 Problem Statement
+Currently, the "Download All" button downloads every single file attached to a stream item or assignment. If an assignment includes both student-submitted PDFs and various informational image attachments or template files, the teacher has no way to select just the PDFs in bulk. They are forced to either download everything and sort it locally, or individually click each student's specific file, which defeats the purpose of the bulk downloader.
+
+### 💡 Proposed Solution
+Introduce a simple file-type filter dropdown or toggle list adjacent to the "Download All" button.
+- What the user sees: When hovering over or clicking near "Download All", a small menu appears showing the available file extensions (e.g., PDF, DOCX, JPG) present in that group.
+- The user can uncheck/check file types. The "Download All" button updates its count (e.g., "Download 15 files" instead of 20).
+- When triggered, the download-all orchestrator only queues files matching the selected extensions.
+
+### 🎯 Why Now
+With the improved support for student work resolution and bulk downloads via the V2 engine, teachers are downloading larger batches of files more reliably. Filtering is a natural next step to enhance this core workflow, making the extension significantly more useful for grading specific submission types without the noise of supplementary materials.
+
+### 📐 Acceptance Criteria
+- [ ] The "Download All" UI element includes a mechanism to select/deselect file types present in the file group.
+- [ ] Unselected file types are excluded from the download queue when "Download All" is clicked.
+- [ ] The button UI correctly reflects the number of files that will be downloaded based on the active filter.
+- [ ] The filter state applies correctly to the `GroupState` without modifying the underlying DOM attachments, so individual downloads still work.
+- [ ] Accessibility: The filter controls are keyboard navigable and accessible to screen readers.
+
+### 🔧 Technical Context
+This feature would involve changes to the download-all group management and UI rendering:
+- `extension/src/download-all/state.ts` and `extension/src/download-all/types.ts`: `GroupState` would need to track active file type filters.
+- `extension/src/download-all/button-controller.ts`: The logic that processes the group download must filter `group.files` based on the selected extensions before queuing.
+- `extension/src/download-all/group-manager.ts`: We need to extract and maintain a unique list of file extensions present in `group.files`.
+- UI rendering: The filter UI needs to be injected alongside the `cqd-download-all-btn`.
+
+### 📊 Estimated Complexity
+Medium (3–5 days). It requires modifying the injected UI for the download-all button to support a dropdown/menu, updating the state model to track filters, and ensuring the queuing logic respects the filter. The hardest part is making the injected UI look native and accessible within the Google Classroom DOM.
+
+### 🔗 Related
+None.

--- a/sage-issue-2.md
+++ b/sage-issue-2.md
@@ -1,0 +1,41 @@
+---
+title: "Sage: show recent download history in popup"
+---
+
+## 🌿 Sage — Extension Feature Suggestion
+**Agent:** Sage | **Day:** Thursday | **Date:** 2026-07-02
+
+---
+
+### 👤 User Story
+As a user (teacher or student), I want to see a history of my recent downloads in the extension's popup, so that I can quickly verify what files I just downloaded and easily access or re-download them if needed without digging through my browser's global download history.
+
+### 🔍 Problem Statement
+Currently, the extension's popup (`extension/entrypoints/popup/App.tsx`) shows aggregate analytics (a donut chart of total downloads by file type) and settings. However, when a user triggers a batch "Download All", especially if a few files fail or take time, there is no localized history log indicating exactly which files were successfully downloaded during the current session. Users have to open the browser's generic download page to check on individual files.
+
+### 💡 Proposed Solution
+Add a "Recent Downloads" section to the extension popup, distinct from the lifetime analytics chart.
+- What the user sees: A list of the last 10–20 files downloaded using the extension.
+- Each entry shows the file name, file type icon, timestamp, and status (Success, Failed).
+- Include a quick "Re-download" action or a link to open the file directly (if the browser API allows).
+
+### 🎯 Why Now
+With the focus on high-volume bulk downloading via "Download All", visibility into individual file statuses is critical. The popup currently lacks actionable day-to-day session data, making it less useful as an immediate reference tool after a large download batch completes.
+
+### 📐 Acceptance Criteria
+- [ ] The popup UI contains a new "Recent Downloads" list view, populated with the latest session downloads.
+- [ ] Each item in the list clearly indicates file name, status (success/failed), and time of download.
+- [ ] The history data is retrieved from local storage or the background script securely, adhering to least-privilege principles (no PII retention beyond the file name and ID for history purposes).
+- [ ] The history list does not exceed a reasonable cap (e.g., last 20 items) to prevent storage bloat.
+- [ ] Accessibility: The list is readable by screen readers and navigable via keyboard.
+
+### 🔧 Technical Context
+- `extension/entrypoints/popup/App.tsx`: Needs a new UI section to render the list.
+- `extension/entrypoints/background/index.ts`: The background worker already observes `chrome.downloads.onChanged` to track download completions and updates the lifetime stats in `local_stats`. It should be extended to maintain a bounded array of recent download events in `chrome.storage.local`.
+- Storage access should remain encapsulated using standard `browserApi.storage.local` calls. Data stored should be minimal (no sensitive URLs, just names and status).
+
+### 📊 Estimated Complexity
+Small to Medium (2–4 days). The background worker already has access to download lifecycle events, so we just need to append minimal metadata to a capped array in local storage. The popup UI work involves building a simple list component and pulling that new array from storage.
+
+### 🔗 Related
+None.


### PR DESCRIPTION
As Sage, the product thinking specialist for the Classroom Quick Downloader extension, I investigated the current codebase, strategy documents, and user pain points (via FAQs) to identify high-impact, frictionless UX improvements.

This PR introduces two feature suggestion Issues formatted as Markdown:
1. **`sage-issue-1.md`**: Proposes adding a file-type filter to the "Download All" feature, allowing teachers to exclude noisy/irrelevant files and download only what they need.
2. **`sage-issue-2.md`**: Proposes adding a session-based recent download history view within the extension popup, preventing users from having to hunt through their browser's generic download history after running a batch.

Additionally, I initialized and appended a summary to my journal (`.jules/sage.md`) to track these filed issues and note areas for the next run.

---
*PR created automatically by Jules for task [11500639727757333929](https://jules.google.com/task/11500639727757333929) started by @adhamhaithameid*