### PR TITLE
🎨 Palette: Update aria-label dynamically for download buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-02 - Dynamic ARIA Label Management
+**Learning:** Screen reader users lose context when the visual state of a button changes dynamically (e.g. from "Downloading" to "Cancel" on hover) without an explicit update to the `aria-label`.
+**Action:** Always dynamically explicitly update `aria-label` attributes alongside visual changes (text/icons) using JS, avoiding reliance on innerText which might not be picked up by screen readers instantly, especially during rapid state transitions like loading or hover events. Include filenames or contextual data when updating labels.

--- a/extension/entrypoints/content/button-factory.ts
+++ b/extension/entrypoints/content/button-factory.ts
@@ -63,7 +63,12 @@ export function createDownloadButton(
       button.classList.add('cqd-cancel');
       const btnLabel = button.querySelector<HTMLSpanElement>('.cqd-label');
       const icon = button.querySelector<HTMLElement>('.cqd-download-icon');
-      if (btnLabel) btnLabel.textContent = t('cancel') || 'Cancel';
+      const fileName = (button.dataset as any).cqdName || '';
+      const cancelText = t('cancel') || 'Cancel';
+
+      button.setAttribute('aria-label', `${cancelText} ${fileName}`.trim());
+
+      if (btnLabel) btnLabel.textContent = cancelText;
       if (icon) {
         icon.className = 'cqd-download-icon';
         icon.style.backgroundImage = `url("${CANCEL_ICON_SVG_URL}")`;
@@ -82,15 +87,20 @@ export function createDownloadButton(
       button.classList.remove('cqd-cancel');
       const btnLabel = button.querySelector<HTMLSpanElement>('.cqd-label');
       const icon = button.querySelector<HTMLElement>('.cqd-download-icon');
+      const fileName = (button.dataset as any).cqdName || '';
 
       if (isUnderlyingLoading) {
-        if (btnLabel) btnLabel.textContent = t('downloading') || 'Downloading...';
+        const text = t('downloading') || 'Downloading...';
+        button.setAttribute('aria-label', `${text} ${fileName}`.trim());
+        if (btnLabel) btnLabel.textContent = text;
         if (icon) {
           icon.className = 'cqd-download-icon cqd-spinner';
           icon.style.backgroundImage = 'none';
         }
       } else if (isUnderlyingTrying) {
-        if (btnLabel) btnLabel.textContent = t('trying') || 'Retrying...';
+        const text = t('trying') || 'Retrying...';
+        button.setAttribute('aria-label', `${text} ${fileName}`.trim());
+        if (btnLabel) btnLabel.textContent = text;
         if (icon) {
           icon.className = 'cqd-download-icon cqd-spinner';
           icon.style.backgroundImage = 'none';

--- a/extension/entrypoints/content/button-state.ts
+++ b/extension/entrypoints/content/button-state.ts
@@ -108,35 +108,43 @@ export function setButtonState(
   icon.style.backgroundImage = `url("${DOWNLOAD_ICON_SVG_URL}")`;
   icon.style.backgroundSize = '';
 
+  const fileName = (button.dataset as any).cqdName || '';
+
   button.classList.add(`cqd-${state}`);
 
   switch (state) {
     case 'idle':
+      button.setAttribute('aria-label', `${t('ariaDownload') || t('download') || 'Download'} ${fileName}`.trim());
       break;
 
     case 'loading':
       icon.style.backgroundImage = 'none';
       icon.className = 'cqd-download-icon cqd-spinner';
       label.textContent = t('downloading');
+      button.setAttribute('aria-label', `${t('downloading')} ${fileName}`.trim());
       button.disabled = false;
       if (isMouseOver) {
-        applyHoverCancelVisual(button, icon, label);
+        applyHoverCancelVisual(button, icon, label, fileName);
       }
       break;
 
-    case 'trying':
+    case 'trying': {
       icon.style.backgroundImage = 'none';
       icon.className = 'cqd-download-icon cqd-spinner';
-      label.textContent = options?.userMessage || t('trying') || 'Retrying...';
+      const msg = options?.userMessage || t('trying') || 'Retrying...';
+      label.textContent = msg;
+      button.setAttribute('aria-label', `${msg} ${fileName}`.trim());
       button.disabled = false;
       if (isMouseOver) {
-        applyHoverCancelVisual(button, icon, label);
+        applyHoverCancelVisual(button, icon, label, fileName);
       }
       break;
+    }
 
     case 'cancel':
       button.disabled = false;
       label.textContent = t('cancel');
+      button.setAttribute('aria-label', `${t('cancel')} ${fileName}`.trim());
       icon.style.backgroundImage = `url("${CANCEL_ICON_SVG_URL}")`;
       icon.style.backgroundSize = '20px 20px';
       break;
@@ -144,6 +152,7 @@ export function setButtonState(
     case 'cancelled':
       button.disabled = true;
       label.textContent = t('cancelled');
+      button.setAttribute('aria-label', `${t('cancelled')} ${fileName}`.trim());
       icon.style.backgroundImage = `url("${CANCEL_ICON_SVG_URL}")`;
       icon.style.backgroundSize = '20px 20px';
       break;
@@ -151,6 +160,7 @@ export function setButtonState(
     case 'success':
       button.classList.add('cqd-success');
       label.textContent = t('downloaded');
+      button.setAttribute('aria-label', `${t('downloaded')} ${fileName}`.trim());
       icon.style.backgroundImage = `url("${SUCCESS_ICON_SVG_URL}")`;
       icon.style.backgroundSize = '20px 20px';
       break;
@@ -158,6 +168,7 @@ export function setButtonState(
     case 'error':
       button.disabled = true;
       label.textContent = options?.userMessage || t('error');
+      button.setAttribute('aria-label', `${options?.userMessage || t('error')} ${fileName}`.trim());
       // stack overflow time
       // stack overflow time
       errorDetail.textContent = options?.userMessage || '';
@@ -173,10 +184,12 @@ export function setButtonState(
 function applyHoverCancelVisual(
   button: HTMLButtonElement,
   icon: HTMLElement,
-  label: HTMLSpanElement
+  label: HTMLSpanElement,
+  fileName: string = ''
 ): void {
   button.classList.add('cqd-cancel');
   label.textContent = t('cancel') || 'Cancel';
+  button.setAttribute('aria-label', `${t('cancel') || 'Cancel'} ${fileName}`.trim());
   icon.className = 'cqd-download-icon';
   icon.style.backgroundImage = `url("${CANCEL_ICON_SVG_URL}")`;
   icon.style.backgroundSize = '20px 20px';


### PR DESCRIPTION
💡 **What**: The UX enhancement added dynamically updates the `aria-label` attribute of download buttons alongside their visual state changes (such as transitioning to a "Cancel" state on hover, or a "Downloading" state). It includes the specific filename in the label.

🎯 **Why**: The user problem it solves is that screen reader users lose context when the visual state of a button changes dynamically without an explicit update to the `aria-label`. Relying only on `innerText` changes might not be picked up by screen readers instantly, especially during rapid state transitions like loading or hover events.

♿ **Accessibility**: Significant a11y improvement for screen reader users, who will now hear the correct action and filename context explicitly announced when interacting with download buttons across different states.

---
*PR created automatically by Jules for task [4668399432444314691](https://jules.google.com/task/4668399432444314691) started by @adhamhaithameid*