### PR TITLE
Quill: student work resolver untested for malformed URL input — add error case tests

### DIFF
--- a/extension/.jules/quill.md
+++ b/extension/.jules/quill.md
@@ -1,0 +1,4 @@
+## 2025-12-14 — Added tests for resolveStudentWorkUrl malformed URL inputs
+**Gap Found:** The `resolveStudentWorkUrl` function handles empty strings, malformed URLs (URLs that cannot be parsed), and non-HTTPS protocols, but these error branches were completely untested in `student-work-resolver.test.ts`.
+**Tests Added/Improved:** `student-work-resolver.test.ts` was modified to include test blocks verifying that empty inputs, unparseable URLs, non-HTTPS protocols (like `http:`), and `javascript:` URLs correctly result in a `{ ok: false }` return object with specific error reasons.
+**Learning:** The URL-parsing logic is often a vector for edge-case errors. It's crucial to explicitly test inputs like `not a url at all`, `http://:::`, and empty strings across all functions dealing with URL validation or creation, as `URL` parsing can fail in unexpected ways depending on the environment.

--- a/extension/tests/student-work-resolver.test.ts
+++ b/extension/tests/student-work-resolver.test.ts
@@ -82,6 +82,30 @@ describe('student_work/resolver', () => {
     globalThis.BroadcastChannel = originalBroadcastChannel;
   });
 
+  it('rejects empty URL input', async () => {
+    const result = await resolveStudentWorkUrl('', { stageTimeoutMs: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('empty_url');
+  });
+
+  it('rejects malformed URL input', async () => {
+    const result = await resolveStudentWorkUrl('http://:::', { stageTimeoutMs: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('malformed_url');
+  });
+
+  it('rejects URLs with non-HTTPS scheme', async () => {
+    const result = await resolveStudentWorkUrl('http://classroom.google.com/g/tg/a/b/c', { stageTimeoutMs: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_scheme');
+  });
+
+  it('rejects javascript: URLs', async () => {
+    const result = await resolveStudentWorkUrl('javascript:alert(1)', { stageTimeoutMs: 10 });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('invalid_scheme');
+  });
+
   it('returns input URL unchanged for non-student-work links', async () => {
     const result = await resolveStudentWorkUrl(
       'https://drive.google.com/file/d/FILE/view',


### PR DESCRIPTION
## 🪶 Quill — Extension Unit Tests
**Agent:** Quill | **Day:** Saturday | **Date:** 2025-12-14

---

### 🪶 Gap Found
The `resolveStudentWorkUrl` function in `extension/src/student_work/resolver.ts` checks for empty strings, malformed URLs (unparseable), and non-HTTPS protocols. However, these error branches were entirely missing from the unit test suite (`extension/tests/student-work-resolver.test.ts`).

### 🎯 Why It Matters
URL parsing and validation is critical for the resolver. Without these tests, a refactor might accidentally remove the scheme check or the malformed URL catch block, allowing bad inputs (like `javascript:` URLs) to proceed further down the resolution chain where they might cause errors or be passed to iframe resolution. These tests document and enforce the expected security and error-handling behavior for URL inputs.

### ✅ Tests Added
- `rejects empty URL input`: verifies that `""` returns `{ ok: false, reason: 'empty_url' }`.
- `rejects malformed URL input`: verifies that an unparseable URL returns `{ ok: false, reason: 'malformed_url' }`.
- `rejects URLs with non-HTTPS scheme`: verifies that `http:` protocols return `{ ok: false, reason: 'invalid_scheme' }`.
- `rejects javascript: URLs`: verifies that `javascript:` protocols return `{ ok: false, reason: 'invalid_scheme' }`.

### 🔬 How to Verify
```bash
cd extension
pnpm run test tests/student-work-resolver.test.ts
```
Expected output: All 22 tests in the file pass.

### 📋 Notes
The `URL` constructor's behavior in JSDOM means that standard string inputs (e.g., `'not a url at all'`) are often treated as valid relative paths appended to `localhost:3000`. To properly test the `try/catch` block for malformed URLs, an input explicitly rejected by the WHATWG URL parser (like `'http://:::'`) is required. This has been logged for future reference.

---
*PR created automatically by Jules for task [3229568906331491748](https://jules.google.com/task/3229568906331491748) started by @adhamhaithameid*