### PR TITLE
Bastion: Oracle store_batch handler untested for oversized body (DoS path)

### DIFF
--- a/.jules/bastion.md
+++ b/.jules/bastion.md
@@ -1,0 +1,4 @@
+## 2026-07-04 — Oracle store_batch missing oversized body test
+**Gap Found:** The Oracle backend `store_batch` handler (`POST /ingest-batch`) lacked test coverage for rejecting requests with a body exceeding the 5MB maximum size limit (enforced via `http.MaxBytesReader`).
+**Tests Added/Improved:** Added `TestIngestBatchHandler_OversizedBody` to `oracle-backend/internal/handlers/store_batch_unit_test.go` to verify that requests exceeding the limit correctly return 400/413 status codes.
+**Learning:** Always verify that input limit checks implemented via middleware or readers (`http.MaxBytesReader`) have explicit unit tests. In Go, `MaxBytesReader` causes `io.ReadAll` to return an error, which often leads to a 400 Bad Request instead of a 413, so tests should accommodate the specific library behavior or both codes.

--- a/oracle-backend/internal/handlers/store_batch_unit_test.go
+++ b/oracle-backend/internal/handlers/store_batch_unit_test.go
@@ -1131,3 +1131,30 @@ func TestRegisterSchemaPaths_NewCountTracksInsertedRowsOnly(t *testing.T) {
 		t.Fatalf("expected newPaths=1, got %v", newPaths)
 	}
 }
+
+func TestIngestBatchHandler_OversizedBody(t *testing.T) {
+	sqlDB := newTestDB(t)
+	defer sqlDB.Close()
+
+	handler := IngestBatchHandler(sqlDB, "secret")
+
+	// Create a body larger than 5MB
+	oversizedBody := strings.Repeat("a", (5<<20)+10)
+
+	req := httptest.NewRequest(http.MethodPost, "/ingest-batch", strings.NewReader(oversizedBody))
+	req.Header.Set("X-DO-SECRET", "secret")
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// MaxBytesReader returns an error when reading the body if it exceeds the limit.
+	// io.ReadAll(r.Body) will return this error, which causes the handler to return 400 Bad Request.
+	// Go 1.20+ adds a specific error for this, but standard behavior returns a read error leading to 400 in this handler.
+	// Let's assert we get 400 Bad Request OR 413 Request Entity Too Large, and verify the body message implies a body read error.
+	if rr.Code != http.StatusBadRequest && rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected status 400 or 413 for oversized body, got %d", rr.Code)
+	}
+	if rr.Code == http.StatusBadRequest && !strings.Contains(rr.Body.String(), "invalid request body") {
+		t.Fatalf("expected 'invalid request body' error message, got %q", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## 🏰 Bastion — Cloudflare & Oracle Tests
**Agent:** Bastion | **Day:** Saturday | **Date:** 2024-03-23

---

### 🏰 Gap Found
The Oracle backend `store_batch` handler (`POST /ingest-batch`) had no explicit test validating that it correctly rejects oversized request bodies exceeding its 5MB limit. 

### 🎯 Why It Matters
Without this test, an accidental removal or misconfiguration of the `http.MaxBytesReader` could allow malicious actors to mount a Denial of Service (DoS) attack by sending massive JSON payloads, exhausting server memory.

### ✅ Tests Added
- `TestIngestBatchHandler_OversizedBody` — verifies that a request payload larger than 5MB correctly triggers a body read error, resulting in a 400 Bad Request status code (which is Go's standard response when `io.ReadAll` fails due to `MaxBytesReader` limits).

### 🔬 How to Verify
Oracle backend tests: `cd oracle-backend && go test ./internal/handlers -run TestIngestBatchHandler_OversizedBody -v`

### 📋 Notes
In Go, `http.MaxBytesReader` will cause the subsequent `io.ReadAll` to fail when the limit is breached. In this specific handler setup, the failure during `io.ReadAll` results in a 400 Bad Request (invalid request body) rather than a 413 Request Entity Too Large. The test properly asserts this behavior.

---
*PR created automatically by Jules for task [6830105574617961066](https://jules.google.com/task/6830105574617961066) started by @adhamhaithameid*