### PR TITLE
Vex: remove unused "tabs" permission from manifest

### DIFF
--- a/.jules/vex.md
+++ b/.jules/vex.md
@@ -1,0 +1,5 @@
+
+## 2026-07-05 — Remove unused 'tabs' permission
+**Finding:** The `tabs` permission was declared in `extension/wxt.config.ts`, but a full source code scan confirmed it was not actually required. Access to Classroom tab URLs is already covered by `host_permissions`.
+**Action:** Removed `tabs` from the permissions array in `wxt.config.ts` to tighten the extension's manifest.
+**Learning:** The background script's use of `chrome.tabs.query` and `tab.url` works perfectly without the `tabs` permission because it only needs to act on domains explicitly permitted by `host_permissions`. It safely ignores undefined URLs for out-of-scope tabs.

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -33,7 +33,6 @@ export default defineConfig({
     homepage_url: "https://classroom-quick-downloader-website.pages.dev",
     permissions: [
       'downloads',
-      'tabs',
       'storage',
       'alarms'
     ],


### PR DESCRIPTION
## 🔍 Vex — Manifest & Permissions Audit
**Agent:** Vex | **Day:** Sunday | **Date:** 2023-10-22

---

### 🚨 Severity
MEDIUM

### 🔍 Finding
The `tabs` permission was declared in `extension/wxt.config.ts`, but a full source code scan confirmed it was not actually required. Access to Classroom tab URLs is already covered by `host_permissions`.

### 🎯 Impact
Declaring the `tabs` permission grants the extension access to sensitive tab properties (URL, title, favicon) across all domains. Removing it enforces the principle of least privilege, reducing the extension's attack surface and improving user privacy.

### 🔧 Fix Applied
Removed `tabs` from the permissions array in `wxt.config.ts`. The background script's use of `chrome.tabs.query` and `tab.url` works perfectly without the `tabs` permission because it only needs to act on domains explicitly permitted by `host_permissions`. It safely ignores undefined URLs for out-of-scope tabs.

### ✅ Verification
- Ran `pnpm run compile` and `pnpm run build` in `extension/`.
- Executed `pnpm run test` and `pnpm run test:smoke` to ensure no tests fail.

### 📋 Notes
Updated `.jules/vex.md` to document the rationale.

---
*PR created automatically by Jules for task [14182403534768282146](https://jules.google.com/task/14182403534768282146) started by @adhamhaithameid*