### PR TITLE
Vault: add try/catch and optional chaining to storage reads to prevent unhandled TypeErrors

### DIFF
--- a/.jules/vault.md
+++ b/.jules/vault.md
@@ -1,0 +1,4 @@
+## 2026-07-05 — Added defensive programming to storage reads
+**Finding:** Missing optional chaining on `chrome.storage.local.get` results in `utils/global-state.ts` and `utils/language-controller.ts`, and missing try/catch in `utils/changelog.ts` operations.
+**Action:** Added optional chaining and try/catch blocks.
+**Learning:** Always use optional chaining (e.g. `res?.[KEY]`) on storage results and wrap operations in try/catch to prevent unhandled TypeErrors from terminating scripts.

--- a/extension/entrypoints/utils/changelog.ts
+++ b/extension/entrypoints/utils/changelog.ts
@@ -154,18 +154,22 @@ function normalizeManualData(): ChangelogData {
 const MANUAL_DATA = normalizeManualData();
 
 async function persistManualCache(data: ChangelogData): Promise<void> {
-  await chrome.storage.local.set({
-    [STORAGE_KEY]: {
-      schemaVersion: 2,
-      cachedItems: data.entries,
-      cachedConfig: data.config,
-      cachedMeta: data.meta,
-      cachedAt: data.lastFetched,
-      revisionToken: data.revisionToken,
-      lastSeenId: data.entries[0]?.id || '',
-      lastChecksum: data.meta?.contentChecksum || '',
-    },
-  });
+  try {
+    await chrome.storage.local.set({
+      [STORAGE_KEY]: {
+        schemaVersion: 2,
+        cachedItems: data.entries,
+        cachedConfig: data.config,
+        cachedMeta: data.meta,
+        cachedAt: data.lastFetched,
+        revisionToken: data.revisionToken,
+        lastSeenId: data.entries[0]?.id || '',
+        lastChecksum: data.meta?.contentChecksum || '',
+      },
+    });
+  } catch (error) {
+    console.warn('Failed to persist manual cache:', error);
+  }
 }
 
 export async function fetchChangelogDetailed(force = false): Promise<ChangelogFetchResult> {
@@ -228,21 +232,30 @@ function migrateSeenState(raw: unknown): SeenState {
 }
 
 export async function markAsSeen(version: string, data?: ChangelogData | null): Promise<void> {
-  const normalizedVersion = normalizeVersion(version);
-  if (!normalizedVersion) return;
-  const storage = await chrome.storage.local.get(SEEN_KEY);
-  const seen = migrateSeenState(storage[SEEN_KEY]);
-  seen[normalizedVersion] = getSeenToken(normalizedVersion, data);
-  await chrome.storage.local.set({ [SEEN_KEY]: seen });
+  try {
+    const normalizedVersion = normalizeVersion(version);
+    if (!normalizedVersion) return;
+    const storage = await chrome.storage.local.get(SEEN_KEY);
+    const seen = migrateSeenState(storage?.[SEEN_KEY]);
+    seen[normalizedVersion] = getSeenToken(normalizedVersion, data);
+    await chrome.storage.local.set({ [SEEN_KEY]: seen });
+  } catch (error) {
+    console.warn('Failed to mark version as seen:', error);
+  }
 }
 
 export async function isVersionSeen(version: string, data?: ChangelogData | null): Promise<boolean> {
-  const normalizedVersion = normalizeVersion(version);
-  if (!normalizedVersion) return false;
-  const storage = await chrome.storage.local.get(SEEN_KEY);
-  const seen = migrateSeenState(storage[SEEN_KEY]);
-  if (!seen[normalizedVersion]) return false;
-  return seen[normalizedVersion] === getSeenToken(normalizedVersion, data);
+  try {
+    const normalizedVersion = normalizeVersion(version);
+    if (!normalizedVersion) return false;
+    const storage = await chrome.storage.local.get(SEEN_KEY);
+    const seen = migrateSeenState(storage?.[SEEN_KEY]);
+    if (!seen[normalizedVersion]) return false;
+    return seen[normalizedVersion] === getSeenToken(normalizedVersion, data);
+  } catch (error) {
+    console.warn('Failed to check if version is seen:', error);
+    return false;
+  }
 }
 
 export function getMatchingRule(config: ChangelogConfig | undefined, currentVersion: string): NotificationRule | null {

--- a/extension/entrypoints/utils/global-state.ts
+++ b/extension/entrypoints/utils/global-state.ts
@@ -4,7 +4,7 @@ export const getGlobalEnabled = async (): Promise<boolean> => {
   try {
     const res = await chrome.storage.local.get(STORAGE_KEY_ENABLED);
     // Default to true if not set
-    return res[STORAGE_KEY_ENABLED] !== false;
+    return res?.[STORAGE_KEY_ENABLED] !== false;
   } catch (error) {
     console.warn('Failed to get global enabled state:', error);
     return true;

--- a/extension/entrypoints/utils/language-controller.ts
+++ b/extension/entrypoints/utils/language-controller.ts
@@ -49,7 +49,7 @@ class LanguageController {
       try {
         if (typeof chrome !== 'undefined' && chrome.storage?.local) {
           const result = await chrome.storage.local.get(STORAGE_KEY);
-          this.state = result[STORAGE_KEY] || cloneDefaultState();
+          this.state = result?.[STORAGE_KEY] || cloneDefaultState();
         } else {
           this.state = cloneDefaultState();
         }


### PR DESCRIPTION
## 🔒 Vault — Storage & Analytics
**Agent:** Vault | **Day:** Sunday | **Date:** 2026-07-05

---

### 🚨 Severity
[MEDIUM]

### 🔒 Finding
Missing optional chaining on `chrome.storage.local.get` results in `utils/global-state.ts` and `utils/language-controller.ts`, and missing try/catch in `utils/changelog.ts` operations.

### 🎯 Impact
Unhandled promise rejections or TypeErrors when the storage API unexpectedly returns undefined or throws an error.

### 🔧 Fix Applied
Added optional chaining and try/catch blocks.

### ✅ Verification
Tested with `pnpm run test` and `pnpm run test:smoke`.

### 📋 Notes
Always use optional chaining (e.g. `res?.[KEY]`) on storage results and wrap operations in try/catch to prevent unhandled TypeErrors from terminating scripts.

---
*PR created automatically by Jules for task [12488842409913822512](https://jules.google.com/task/12488842409913822512) started by @adhamhaithameid*