### PR TITLE
Specter: debounce MutationObserver callback in Orchestrator to reduce handleMutations frequency

### DIFF
--- a/.jules/specter.md
+++ b/.jules/specter.md
@@ -1,0 +1,4 @@
+## 2024-05-14 — Debounced Orchestrator DOM Observer
+**Finding:** The primary `MutationObserver` in `extension/src/v2/orchestrator/orchestrator.ts` fed every mutation batch directly to `engine.handleMutations()` without any throttling. In Google Classroom's stream view, this triggers hundreds of times per second during initial load or heavy DOM operations, burning CPU needlessly.
+**Action:** Introduced a 50ms `debounceTimer` and a `pendingMutations` accumulation array in `setupDomObserver`. This batches rapid mutations into a single `handleMutations` call, significantly lowering execution frequency while ensuring no mutations are lost. Also added cleanup logic in `stop()` and `abortCurrentPage()`.
+**Learning:** For performance agents, always make sure to clear timeouts on component unmounts (`abortCurrentPage`/`stop`) and buffer mutation records (`[...pendingMutations]`) when delaying `MutationObserver` processing to prevent data loss.

--- a/extension/src/v2/orchestrator/orchestrator.ts
+++ b/extension/src/v2/orchestrator/orchestrator.ts
@@ -67,6 +67,12 @@ export class Orchestrator {
   /** The single MutationObserver that feeds all active engines */
   private domObserver: MutationObserver | null = null;
 
+  /** Timer for debouncing mutations */
+  private debounceTimer: number | null = null;
+
+  /** Pending mutations waiting to be processed */
+  private pendingMutations: MutationRecord[] = [];
+
   /**
    * AbortController for the current page's lifecycle.
    * When the user navigates, we abort this controller, which
@@ -151,11 +157,17 @@ export class Orchestrator {
     // 2. Abort current page lifecycle
     this.abortCurrentPage();
 
-    // 3. Disconnect DOM observer
+    // 3. Disconnect DOM observer and clear timer
     if (this.domObserver) {
       this.domObserver.disconnect();
       this.domObserver = null;
     }
+
+    if (this.debounceTimer !== null) {
+      window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.pendingMutations = [];
 
     // 4. Destroy all active engines
     for (const engine of this.activeEngines) {
@@ -331,16 +343,35 @@ export class Orchestrator {
     this.domObserver = new MutationObserver((mutations) => {
       if (!this.running) return;
 
-      // Feed mutations to ALL active engines
-      for (const engine of this.activeEngines) {
-        try {
-          engine.handleMutations(mutations);
-        } catch (e) {
-          console.error(
-            `[CQD Orchestrator] Error in ${engine.name}.handleMutations:`, e,
-          );
+      // Accumulate mutations
+      this.pendingMutations.push(...mutations);
+
+      // Debounce: batch rapid mutations into a single processing tick
+      // Classroom's stream page can trigger hundreds of mutations during initial render
+      if (this.debounceTimer !== null) return;
+
+      this.debounceTimer = window.setTimeout(() => {
+        this.debounceTimer = null;
+
+        if (!this.running) {
+          this.pendingMutations = [];
+          return;
         }
-      }
+
+        const batchedMutations = [...this.pendingMutations];
+        this.pendingMutations = [];
+
+        // Feed mutations to ALL active engines
+        for (const engine of this.activeEngines) {
+          try {
+            engine.handleMutations(batchedMutations);
+          } catch (e) {
+            console.error(
+              `[CQD Orchestrator] Error in ${engine.name}.handleMutations:`, e,
+            );
+          }
+        }
+      }, 50); // 50ms debounce
     });
 
     // Start observing
@@ -388,10 +419,16 @@ export class Orchestrator {
       this.pageAbortController = null;
     }
 
-    // 2. Disconnect DOM observer
+    // 2. Disconnect DOM observer and clear timer
     if (this.domObserver) {
       this.domObserver.disconnect();
     }
+
+    if (this.debounceTimer !== null) {
+      window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.pendingMutations = [];
 
     // 3. Destroy active engines
     for (const engine of this.activeEngines) {


### PR DESCRIPTION
## 👻 Specter — Extension Performance
**Agent:** Specter | **Day:** Tuesday | **Date:** 2024-05-14

---

### ⚡ Performance Finding
`extension/src/v2/orchestrator/orchestrator.ts`, `setupDomObserver`: The primary `MutationObserver` fed every mutation batch directly to `engine.handleMutations()` without throttling.

### 📊 Estimated Impact
In Google Classroom's stream view, mutations can trigger hundreds of times per second during initial load or heavy DOM operations, burning CPU needlessly. This fix batches rapid mutations into single calls, drastically lowering the execution rate without losing mutations.

### 🔧 Optimisation Applied
Introduced a 50ms `debounceTimer` and a `pendingMutations` accumulation array in `setupDomObserver`. This batches rapid mutations into a single `handleMutations` call, significantly lowering execution frequency. Also added cleanup logic in `stop()` and `abortCurrentPage()` to prevent memory leaks and dangling timeouts.

### ✅ Verification
Ran `pnpm run compile`, `pnpm run test`, and `pnpm run test:stress` in `extension/`, plus `pnpm run test:smoke` at the root.

### 📋 Notes
Ensure that the delay of 50ms isn't causing observable latency for injecting UI components. If any user-reported visual latency arises, we can reconsider a slightly lower delay, but 50ms appears imperceptible while substantially minimizing redundant rescans.

---
*PR created automatically by Jules for task [9471089840294698449](https://jules.google.com/task/9471089840294698449) started by @adhamhaithameid*