### PR TITLE
Aria: layout missing skip-to-main-content link and focus management — keyboard users cannot skip nav

### DIFF
--- a/.jules/aria.md
+++ b/.jules/aria.md
@@ -1,0 +1,4 @@
+## 2024-05-15 — Added skip link and focus management to layout
+**Finding:** Priority 5 and 6: The layout was missing a skip navigation link, making keyboard navigation difficult. Furthermore, route transitions caused screen reader users to lose focus (no `afterNavigate` focus management). WCAG 2.4.1 and SPA best practices failure.
+**Action:** Added a `.skip-nav` link (visible on focus) and a `<main>` container with `id="main-content"` and `tabindex="-1"` in `website/src/routes/+layout.svelte`. Implemented `afterNavigate` from SvelteKit to shift focus to the main container post route changes.
+**Learning:** Remember that SvelteKit being an SPA requires intentional programmatic focus shifting during client-side navigations, and global structural elements like skip links belong in `+layout.svelte`.

--- a/website/src/routes/+layout.svelte
+++ b/website/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { afterNavigate } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import logo from '$lib/assets/cqd-logo.svg';
@@ -49,6 +50,15 @@
   function toggleMobileMenu(): void {
     mobileNavOpen = !mobileNavOpen;
   }
+
+  afterNavigate(() => {
+    // Move focus to main content after every route change
+    // Prevents screen reader users from being lost after navigation
+    const mainContent = document.querySelector('#main-content');
+    if (mainContent) {
+      (mainContent as HTMLElement).focus();
+    }
+  });
 
   function closeMobileMenu(): void {
     mobileNavOpen = false;
@@ -151,6 +161,7 @@
 <LoadingScreen />
 
 <div class="site-shell" class:o2-fullscreen={hideChrome}>
+  <a href="#main-content" class="skip-nav">Skip to main content</a>
   {#if !hideChrome}
   <header class="l2-nav-shell">
     <div class="l2-nav-inner l2-nav-fullwidth">
@@ -238,6 +249,8 @@
   {/if}
 
   <main
+    id="main-content"
+    tabindex="-1"
     class:site-main={!isOverviewStyleRoute && !hideChrome}
     class:site-main-overview-style={isOverviewStyleRoute && !hideChrome}
     class:l2-wrap={!isOverviewStyleRoute && !hideChrome}
@@ -294,6 +307,25 @@
   .site-shell.o2-fullscreen {
     overflow: hidden;
     height: 100vh;
+  }
+
+  /* Skip link visible only on focus — WCAG 2.4.1 */
+  .skip-nav {
+    position: absolute;
+    top: -100%;
+    left: 0;
+    padding: 0.5rem 1rem;
+    background: var(--gc-green);
+    color: white;
+    z-index: 999;
+    text-decoration: none;
+  }
+  .skip-nav:focus {
+    top: 0;
+  }
+
+  main#main-content:focus {
+    outline: none;
   }
 
   .site-main {


### PR DESCRIPTION
## ♿ Aria — Website Accessibility
**Agent:** Aria | **Day:** Wednesday | **Date:** 2024-05-15

---

### ♿ WCAG Violation
WCAG 2.1 AA — 2.4.1 Bypass Blocks (Skip Navigation) and SPA focus management best practices for WCAG 2.4.3 Focus Order.

### 🔍 Finding
`website/src/routes/+layout.svelte` was missing a skip navigation link and focus management after SvelteKit client-side route transitions.

### 👤 User Impact
Keyboard-only users were forced to tab through the entire navigation on every single page. Screen reader users were losing their context completely after navigating between routes as focus was not managed.

### 🔧 Fix Applied
- Added `<a href="#main-content" class="skip-nav">Skip to main content</a>` to the site layout.
- Added `id="main-content"` and `tabindex="-1"` to the `<main>` tag.
- Used SvelteKit's `afterNavigate` to focus on the `main` tag programmatically after route change.
- Added CSS to handle focus visibility correctly.

### ✅ Verification
- Checked that the skip link is visible when focused.
- Verified that pressing enter on skip link shifts focus to the main content area.
- Verified that focus shifts to `main-content` automatically after client-side SPA navigation.
- Ran tests: `pnpm run test:smoke` and `pnpm run test:routes` passed.

### 📋 Notes
Documented in `.jules/aria.md` journal.

---
*PR created automatically by Jules for task [12778189310366344137](https://jules.google.com/task/12778189310366344137) started by @adhamhaithameid*