### PR TITLE
Signal: block search indexing of internal email preview pages

### DIFF
--- a/.jules/signal.md
+++ b/.jules/signal.md
@@ -1,0 +1,4 @@
+## 2026-07-08 — Internal email preview pages indexed
+**Finding:** The internal email preview routes `/emails` and `/emails2` lack the `noindex={true}` tag in their `<SeoMeta>` component and are not blocked in `robots.txt`, risking accidental search engine indexing of internal advertisement mockups.
+**Action:** Added `noindex={true}` to both pages' `<SeoMeta>` and added `Disallow: /emails` and `Disallow: /emails2` directives to `website/src/routes/robots.txt/+server.ts`.
+**Learning:** Internal or draft routes (like email previews) must be explicitly disallowed in `robots.txt` and flagged with `noindex` metadata to prevent accidental search indexing.

--- a/website/src/routes/emails/+page.svelte
+++ b/website/src/routes/emails/+page.svelte
@@ -12,6 +12,7 @@
   description="Browser preview of the Classroom Quick Downloader advertisement email."
   path="/emails"
   keywords="classroom quick downloader email, classroom extension email ad"
+  noindex={true}
 />
 
 <section class="emails-page">

--- a/website/src/routes/emails2/+page.svelte
+++ b/website/src/routes/emails2/+page.svelte
@@ -75,6 +75,7 @@
   description="Svelte-native email preview for Classroom Quick Downloader with consistent cross-device rendering."
   path="/emails2"
   keywords="classroom quick downloader email preview, svelte email page"
+  noindex={true}
 />
 
 <section class="emails2-page" aria-label="Classroom Quick Downloader email preview">

--- a/website/src/routes/robots.txt/+server.ts
+++ b/website/src/routes/robots.txt/+server.ts
@@ -16,6 +16,8 @@ Disallow: /uninstall
 Disallow: /404
 Disallow: /overview-editor
 Disallow: /landing2
+Disallow: /emails
+Disallow: /emails2
 
 Sitemap: ${siteUrl}/sitemap.xml
 ${host ? `Host: ${host}\n` : ''}


### PR DESCRIPTION
## 📶 Signal — Website SEO
**Agent:** Signal | **Day:** Wednesday | **Date:** 2026-07-08

---

### 📶 SEO Finding
The internal email preview pages at `/emails` and `/emails2` lack `noindex` meta tags and are not blocked in `robots.txt`. This creates a risk that search engines might index these internal test/draft pages and surface them in public search results.

### 🎯 Search Impact
Indexing internal test pages can dilute the website's authority and present incomplete or out-of-context mockup pages to users searching for the product, degrading the search experience.

### 🔧 Fix Applied
- Added `noindex={true}` to the `<SeoMeta>` component in both `website/src/routes/emails/+page.svelte` and `website/src/routes/emails2/+page.svelte`.
- Added `Disallow: /emails` and `Disallow: /emails2` directives to the `robots.txt` generation logic in `website/src/routes/robots.txt/+server.ts`.
- Logged the finding and action in `.jules/signal.md`.

### ✅ Verification
- Ran `pnpm run build` and `pnpm run check` to ensure no SvelteKit build regressions.
- Ran `pnpm run test:smoke` to verify overall monorepo health.
- Verified that `robots.txt` outputs the expected `Disallow` directives via `cat`.

### 📋 Notes
Future Signal runs should ensure that any new internal routes (e.g., test pages, mockups, or internal tools) consistently apply both the `noindex` tag and the corresponding `robots.txt` disallow rule.

---
*PR created automatically by Jules for task [16200520987404340543](https://jules.google.com/task/16200520987404340543) started by @adhamhaithameid*