### PR TITLE
Ember: respect prefers-reduced-motion for all JS-triggered pulse animations

### DIFF
--- a/extension/entrypoints/content/download-handler.ts
+++ b/extension/entrypoints/content/download-handler.ts
@@ -66,8 +66,14 @@ export async function handleCancelClick(button: HTMLButtonElement): Promise<void
     }
   }
 
-  button.classList.add('cqd-cancel-click-anim');
-  setTimeout(() => button.classList.remove('cqd-cancel-click-anim'), 400);
+  const prefersReducedMotion = typeof window !== 'undefined' &&
+                               typeof window.matchMedia === 'function' &&
+                               window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (!prefersReducedMotion) {
+    button.classList.add('cqd-cancel-click-anim');
+    setTimeout(() => button.classList.remove('cqd-cancel-click-anim'), 400);
+  }
 
   setButtonState(button, 'cancelled');
 

--- a/extension/entrypoints/content/pulse-effect.ts
+++ b/extension/entrypoints/content/pulse-effect.ts
@@ -120,6 +120,15 @@ export function triggerPulseEffect(post: HTMLElement, type: PulseType): void {
     return; // Do nothing if animation is in progress
   }
   
+  const prefersReducedMotion = typeof window !== 'undefined' &&
+                               typeof window.matchMedia === 'function' &&
+                               window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (prefersReducedMotion) {
+    // If reduced motion is preferred, just return immediately without animating
+    return;
+  }
+
   // Mark as animating
   post.setAttribute(DEBOUNCE_ATTR, 'true');
   

--- a/extension/src/v2/render/flag-renderer.ts
+++ b/extension/src/v2/render/flag-renderer.ts
@@ -346,7 +346,10 @@ function _handleBadgeClick(e: Event): void {
 
   // Pulse animation
   const badge = target.closest('.cqd-v2-flag') as HTMLElement;
-  if (badge) {
+  const prefersReducedMotion = typeof window !== 'undefined' &&
+                               typeof window.matchMedia === 'function' &&
+                               window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (badge && !prefersReducedMotion) {
     badge.classList.add('cqd-pulsing');
     setTimeout(() => badge.classList.remove('cqd-pulsing'), 600);
   }


### PR DESCRIPTION
## 🔥 Ember — Extension UX Micro-Improvements
**Agent:** Ember | **Day:** Wednesday | **Date:** 2026-07-08

---

### 🔥 UX Finding
JS-triggered animations in the extension (pulse effects for badges and flags, and the cancel click animation for download buttons) currently ignore the user's OS/browser `prefers-reduced-motion` setting. Because these animations are triggered by adding classes via JavaScript (e.g., `classList.add('cqd-pulsing')`), they bypass purely CSS-based media queries unless explicitly checked in the script.

### 👤 User Impact
Users with vestibular disorders or motion sensitivities are subjected to unexpected, jarring animations (pulsing and shaking) when they interact with the extension's UI elements, causing discomfort and violating accessibility standards.

### 🔧 Improvement Applied
Added explicit `window.matchMedia('(prefers-reduced-motion: reduce)').matches` checks before applying animation classes in `pulse-effect.ts`, `flag-renderer.ts`, and `download-handler.ts`. If the user prefers reduced motion, the animation is skipped and the UI transitions instantly or without the effect.

### ✅ Verification
1. Open OS settings and enable "Reduce motion".
2. Open a Google Classroom page.
3. Click a comment/edited badge (no pulse should occur).
4. Start a download and quickly click cancel (no shake animation should occur).
5. All test suites pass without regression: `cd extension && pnpm run compile && pnpm run test && pnpm run build`, and `pnpm run test:smoke` at the root.

### 📋 Notes
Future JS-triggered animations in the content script must remember to include this check, as CSS media queries alone are insufficient when JS is driving the state changes.

---
*PR created automatically by Jules for task [9382708334341183653](https://jules.google.com/task/9382708334341183653) started by @adhamhaithameid*