### PR TITLE
Stamp: sync oracleBackend version in manual and generated changelog files

### DIFF
--- a/.jules/stamp.md
+++ b/.jules/stamp.md
@@ -1,0 +1,8 @@
+## 2026-06-10 — Found oracleBackend mismatch in data/changelog/release-version.manual.json and website/src/lib/content/release-version.manual.generated.json
+**Extension Version (canonical):** 1.5.5
+**Files Checked:** extension/package.json, data/changelog/release-version.manual.json, website/src/lib/content/release-version.manual.generated.json, website/src/lib/content/release-version.manual.generated.ts, extension/wxt.config.ts, data/changelog/extension-changelog.manual.md, oracle-backend/package.json, cloudflare-worker/package.json, website/package.json
+**Discrepancies Found:**
+- `data/changelog/release-version.manual.json` has oracleBackend `5.0.0`, but `oracle-backend/package.json` is `6.0.0`.
+- `website/src/lib/content/release-version.manual.generated.json` and `.ts` have oracleBackend `5.0.0` but should be `6.0.0`.
+**Action Taken:** Will fix
+**Learning:** Found version mismatch in cross-component generated files for oracle-backend.

--- a/data/changelog/release-version.manual.json
+++ b/data/changelog/release-version.manual.json
@@ -1,6 +1,6 @@
 {
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 }

--- a/website/src/lib/content/release-version.manual.generated.json
+++ b/website/src/lib/content/release-version.manual.generated.json
@@ -2,6 +2,6 @@
   "generatedAt": 1781017451093,
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 }

--- a/website/src/lib/content/release-version.manual.generated.ts
+++ b/website/src/lib/content/release-version.manual.generated.ts
@@ -3,6 +3,6 @@ export const WEBSITE_MANUAL_RELEASE_VERSION = {
   "generatedAt": 1781017451093,
   "extension": "1.5.5",
   "cloudflareWorker": "3.0.0",
-  "oracleBackend": "5.0.0",
+  "oracleBackend": "6.0.0",
   "websiteLabel": "v1.5.5"
 } as const;


### PR DESCRIPTION
Synchronized `oracleBackend` version `6.0.0` from `oracle-backend/package.json` to `data/changelog/release-version.manual.json`, `website/src/lib/content/release-version.manual.generated.json`, and `website/src/lib/content/release-version.manual.generated.ts`.

Updated `.jules/stamp.md` with findings.

---
*PR created automatically by Jules for task [4659156793199630682](https://jules.google.com/task/4659156793199630682) started by @adhamhaithameid*